### PR TITLE
ENH:  N4 + B-spline scattered data fitting.

### DIFF
--- a/antstorch/bspline_flow/__init__.py
+++ b/antstorch/bspline_flow/__init__.py
@@ -1,7 +1,14 @@
 """Differentiable ITK-compatible cubic B-spline field synthesis."""
 
 from .bspline_domain import BSplineDomain
-from .bspline_synthesis import CubicBSplineSynthesis, cubic_bspline_basis, synthesize_bspline_velocity
+from .bspline_scattered_data import fit_bspline_displacement_field, fit_bspline_object_to_scattered_data
+from .bspline_synthesis import (
+    CubicBSplineSynthesis,
+    cubic_bspline_basis,
+    fit_bspline_coefficients,
+    refine_bspline_coefficients,
+    synthesize_bspline_velocity,
+)
 from .deterministic_registration import DeterministicBSplineRegistration
 from .n4_bias_field_correction import N4BiasFieldCorrection, n4_bias_field_correction
 from .scaling_and_squaring import ScalingAndSquaring, scaling_and_squaring
@@ -20,6 +27,10 @@ __all__ = [
     "BSplineDomain",
     "CubicBSplineSynthesis",
     "cubic_bspline_basis",
+    "fit_bspline_coefficients",
+    "fit_bspline_displacement_field",
+    "fit_bspline_object_to_scattered_data",
+    "refine_bspline_coefficients",
     "synthesize_bspline_velocity",
     "DeterministicBSplineRegistration",
     "N4BiasFieldCorrection",

--- a/antstorch/bspline_flow/bspline_scattered_data.py
+++ b/antstorch/bspline_flow/bspline_scattered_data.py
@@ -1,0 +1,515 @@
+"""Differentiable, tensor-only scattered-data B-spline fitting.
+
+PyTorch analogues of ANTsPy's ``fit_bspline_object_to_scattered_data`` and
+``fit_bspline_displacement_field`` (``ants/registration/`` -- themselves
+wrappers around ITK's ``itkBSplineScatteredDataPointSetToImageFilter`` and
+``itkDisplacementFieldToBSplineImageFilter``). Argument names and semantics
+follow ANTsPy closely; the differences are called out in each function's
+docstring.
+
+Unlike :func:`~.bspline_synthesis.fit_bspline_coefficients` (a single
+dense-grid least-squares fit), this module implements ITK's actual
+multi-level scattered-data algorithm: at each of ``number_of_fitting_levels``
+levels, fit the current residual at every sample -> add it to a running
+coefficient lattice -> exactly refine that lattice for the next, finer
+level (see :func:`~.bspline_synthesis.refine_bspline_coefficients`). This is
+the same accumulate/refine pattern
+:func:`~.n4_bias_field_correction.n4_bias_field_correction` uses internally,
+generalized here from N4's regular shrunk-image grid to arbitrary scattered
+points with independent parametric locations.
+"""
+
+from typing import Optional, Sequence, Tuple, Union
+
+import torch
+from torch import Tensor
+
+from .bspline_domain import BSplineDomain
+from .bspline_synthesis import (
+    _bspline_fit_context,
+    _bspline_fit_geometry,
+    _bspline_fit_solve,
+    _as_bools,
+    cubic_bspline_basis,
+    refine_bspline_coefficients,
+    synthesize_bspline_velocity,
+)
+
+
+def _parametric_to_u(
+    parametric_coordinate: Tensor,
+    origin: float,
+    spacing: float,
+    domain_size: int,
+    lattice_size: int,
+    closed: bool,
+) -> Tensor:
+    """Map a physical/parametric coordinate to this package's internal
+    B-spline u-parametrization, ``[0, spans]``, using the same "domain
+    edge-to-edge spans the full parametric range" convention as every other
+    u-mapping in this package (see ``_bspline_fit_geometry`` and
+    ``synthesize_bspline_velocity``). For a coordinate that lands exactly on
+    a dense, regularly-spaced grid of ``domain_size`` points running from
+    ``origin`` to ``origin + spacing*(domain_size-1)``, this reduces exactly
+    to ``_bspline_fit_geometry``'s grid-index formula -- so a scattered fit
+    over a domain's own grid points agrees with the dense-grid fit path.
+    """
+    spans = float(lattice_size if closed else lattice_size - 3)
+    normalized = (parametric_coordinate - origin) / spacing
+    u = normalized * (spans / float(domain_size - 1))
+    if closed:
+        return u
+    upper = torch.nextafter(u.new_tensor(spans), u.new_tensor(float("-inf")))
+    return u.clamp(0.0, upper)
+
+
+def _bspline_fit_geometry_points(
+    parametric_u: Sequence[Tensor],
+    lattice_itk: Sequence[int],
+    closed_axes: Sequence[bool],
+    eps: float,
+):
+    """Support-point indices/weights for a B-spline scattered-data update at
+    arbitrary (non-grid) parametric points -- the scattered-point analogue
+    of ``_bspline_fit_geometry``. Shares the exact same knot convention and
+    per-point accumulation math (and the exact same downstream
+    ``_bspline_fit_context``/``_bspline_fit_solve``, which only ever look at
+    the returned ``(indices, basis_values, squared_sum, coefficient_count)``
+    tuple and are agnostic to whether it came from a grid or scattered
+    points), but without assuming the points form a regular grid.
+
+    ``parametric_u`` is one 1-D tensor of length ``P`` per axis (ITK order),
+    each already this axis's u-coordinate in ``[0, spans]`` (or any real
+    value for a closed axis -- see ``_parametric_to_u``).
+    """
+    dimension = len(lattice_itk)
+    device = parametric_u[0].device
+    dtype = parametric_u[0].dtype
+    point_count = parametric_u[0].shape[0]
+
+    neighbors, basis = [], []
+    for u, lattice_size, closed in zip(parametric_u, lattice_itk, closed_axes):
+        base = torch.floor(u).to(torch.long)
+        local = torch.arange(4, device=device)
+        index = base[:, None] + local
+        neighbors.append(index.remainder(lattice_size) if closed else index)
+        basis.append(cubic_bspline_basis(u[:, None] - index.to(u.dtype) + 1.0))
+
+    support_indices, support_basis = [], []
+    strides, stride = [], 1
+    for size in lattice_itk:
+        strides.append(stride)
+        stride *= size
+    from itertools import product
+
+    for support in product(range(4), repeat=dimension):
+        index = sum(neighbors[d][:, support[d]] * strides[d] for d in range(dimension))
+        value = torch.ones(point_count, dtype=dtype, device=device)
+        for d in range(dimension):
+            value = value * basis[d][:, support[d]]
+        support_indices.append(index)
+        support_basis.append(value)
+
+    indices = torch.stack(support_indices)
+    basis_values = torch.stack(support_basis)
+    squared_sum = basis_values.square().sum(dim=0).clamp_min(eps)
+    coefficient_count = stride
+    return indices, basis_values, squared_sum, coefficient_count
+
+
+def _concat_bspline_fit_geometries(geometries):
+    """Merge independently-built geometries (e.g. one from a dense grid, one
+    from scattered points) into a single one, so ``_bspline_fit_context``
+    accumulates ``omega`` from every sample together. Valid because
+    ``indices``/``basis_values``/``squared_sum`` are all per-sample -- each
+    sample's contribution never depends on any other sample -- and every
+    geometry being merged shares the same ``lattice_itk`` (hence the same
+    ``coefficient_count``).
+    """
+    indices = torch.cat([g[0] for g in geometries], dim=1)
+    basis_values = torch.cat([g[1] for g in geometries], dim=1)
+    squared_sum = torch.cat([g[2] for g in geometries], dim=0)
+    coefficient_count = geometries[0][3]
+    return indices, basis_values, squared_sum, coefficient_count
+
+
+def _evaluate_bspline_at_points(coefficients: Tensor, geometry) -> Tensor:
+    """Evaluate a coefficient lattice at the points described by
+    ``geometry`` (from ``_bspline_fit_geometry_points``) -- the
+    scattered-point analogue of ``synthesize_bspline_velocity``'s
+    per-chunk gather. Reuses the exact ``(indices, basis_values)`` support
+    tables a fit step already built, so evaluating the current fit's
+    reconstruction at the fitted points (to form the next level's residual)
+    costs no extra geometry work.
+    """
+    indices, basis_values, _, _ = geometry
+    batch_channels = coefficients.shape[0] * coefficients.shape[1]
+    flat_coefficients = coefficients.reshape(batch_channels, -1)
+    support_count, point_count = indices.shape
+    gathered = flat_coefficients.index_select(1, indices.reshape(-1)).reshape(
+        batch_channels, support_count, point_count
+    )
+    values = (gathered * basis_values[None]).sum(dim=1)
+    return values.reshape(coefficients.shape[0], coefficients.shape[1], point_count)
+
+
+def _mesh_size_to_lattice(mesh_size, dimension: int, spline_order: int, closed_axes) -> Tuple[int, ...]:
+    if spline_order != 3:
+        raise NotImplementedError("only cubic B-splines (spline_order=3) are currently supported")
+    if isinstance(mesh_size, int):
+        mesh_sizes = (mesh_size,) * dimension
+    else:
+        mesh_sizes = tuple(int(v) for v in mesh_size)
+        if len(mesh_sizes) != dimension:
+            raise ValueError(f"mesh_size must have {dimension} values")
+    lattice_itk = tuple(m + spline_order for m in mesh_sizes)
+    for size, closed in zip(lattice_itk, closed_axes):
+        if closed and size < 2 * spline_order + 1:
+            raise ValueError("closed parametric dimensions require mesh_size > spline_order")
+        if size < 4:
+            raise ValueError("mesh_size must be at least 1 per dimension")
+    return lattice_itk
+
+
+def fit_bspline_object_to_scattered_data(
+    scattered_data,
+    parametric_data,
+    parametric_domain_origin: Sequence[float],
+    parametric_domain_spacing: Sequence[float],
+    parametric_domain_size: Sequence[int],
+    is_parametric_dimension_closed: Optional[Union[bool, Sequence[bool]]] = None,
+    data_weights=None,
+    number_of_fitting_levels: int = 4,
+    mesh_size: Union[int, Sequence[int]] = 1,
+    spline_order: int = 3,
+    *,
+    device=None,
+    dtype: torch.dtype = torch.float32,
+    eps: float = 1e-6,
+    stable_accumulation: Optional[bool] = None,
+    return_coefficients: bool = False,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    """Fit a smooth cubic B-spline object to scattered data -- a PyTorch
+    analogue of ANTsPy's ``fit_bspline_object_to_scattered_data`` (a wrapper
+    for ``itkBSplineScatteredDataPointSetToImageFilter``), entirely with
+    differentiable tensor ops (no ITK, no NumPy in the fitting path).
+
+    Argument names and semantics mirror ANTsPy so existing ANTsPy call
+    sites translate directly: ``scattered_data`` is ``(P, data_dimension)``,
+    ``parametric_data`` is ``(P, parametric_dimension)`` giving each row's
+    location in the B-spline object's parametric domain (defined by
+    ``parametric_domain_origin``/``_spacing``/``_size``, ITK order).
+
+    Differences from ANTsPy, by design:
+
+    * Only 2-D or 3-D parametric domains are supported (this package's
+      ``BSplineDomain``/``synthesize_bspline_velocity`` do not represent
+      1-D curves or 4-D fields), and only ``spline_order=3`` (cubic,
+      matching the rest of this package).
+    * The return value is always a dense tensor sampling the fitted object
+      over the full parametric domain, shape ``(1, data_dimension,
+      *reversed(parametric_domain_size))`` -- this package's usual
+      ``(N, C, *spatial)`` convention with ``N=1`` -- rather than a raw
+      curve array or an ANTsImage. Pass ``return_coefficients=True`` to
+      additionally get the raw coefficient lattice, e.g. for feeding into
+      ``synthesize_bspline_velocity`` at a different resolution/domain.
+      Concretely, this means the result is the ANTsPy/ITK output
+      *transposed*: ``ants.fit_bspline_object_to_scattered_data(...)
+      .numpy()`` keeps ITK's direct axis order (``(size_x, size_y[,
+      size_z])``), while this function reverses it (``(N, C, size_y,
+      size_x)`` in 2-D). ``result[0, c].numpy() == ants_result.numpy()[..., c].T``
+      (2-D; a full axis reversal, not a literal ``.T``, in 3-D) -- the same
+      relationship already used to compare ``n4_bias_field_correction``
+      against ANTsPy (see ``test_n4_bias_field_correction.py``). Numerically
+      the fit agrees with ANTsPy to float precision once this axis
+      reversal is accounted for.
+
+    Multi-level fitting matches ITK exactly: at each of
+    ``number_of_fitting_levels`` levels (starting from ``mesh_size`` control
+    points and doubling each level via ``refine_bspline_coefficients``), the
+    residual between ``scattered_data`` and the current accumulated fit is
+    computed at every point and added to the running coefficient lattice --
+    the same accumulate/refine pattern used by ``n4_bias_field_correction``.
+    """
+    scattered_data = torch.as_tensor(scattered_data, dtype=dtype, device=device)
+    parametric_data = torch.as_tensor(parametric_data, dtype=scattered_data.dtype, device=scattered_data.device)
+    device = scattered_data.device
+    dtype = scattered_data.dtype
+
+    if scattered_data.ndim != 2:
+        raise ValueError("scattered_data must be 2-D (points, data_dimension)")
+    if parametric_data.ndim != 2:
+        raise ValueError("parametric_data must be 2-D (points, parametric_dimension)")
+    if scattered_data.shape[0] != parametric_data.shape[0]:
+        raise ValueError("scattered_data and parametric_data must have the same number of points")
+
+    parametric_dimension = parametric_data.shape[1]
+    data_dimension = scattered_data.shape[1]
+    point_count = scattered_data.shape[0]
+    if parametric_dimension not in (2, 3):
+        raise NotImplementedError(
+            "only 2-D or 3-D parametric domains are currently supported (no 1-D curve fitting yet)"
+        )
+    if number_of_fitting_levels < 1:
+        raise ValueError("number_of_fitting_levels must be at least 1")
+
+    origin = tuple(float(v) for v in parametric_domain_origin)
+    spacing = tuple(float(v) for v in parametric_domain_spacing)
+    domain_size = tuple(int(v) for v in parametric_domain_size)
+    if len(origin) != parametric_dimension or len(spacing) != parametric_dimension or len(domain_size) != parametric_dimension:
+        raise ValueError("parametric_domain_origin/spacing/size must each have parametric_dimension values")
+
+    closed_axes = _as_bools(
+        False if is_parametric_dimension_closed is None else is_parametric_dimension_closed, parametric_dimension
+    )
+    lattice_itk = _mesh_size_to_lattice(mesh_size, parametric_dimension, spline_order, closed_axes)
+
+    if data_weights is None:
+        weight_points = scattered_data.new_ones(point_count)
+    else:
+        weight_points = torch.as_tensor(data_weights, dtype=dtype, device=device).reshape(-1)
+        if weight_points.shape[0] != point_count:
+            raise ValueError("data_weights must have one value per point")
+    if stable_accumulation is None:
+        stable_accumulation = device.type == "mps"
+
+    values_flat = scattered_data.t().reshape(data_dimension, point_count)
+    weight_flat = weight_points.unsqueeze(0).expand(data_dimension, -1)
+
+    accumulated_coefficients = torch.zeros(
+        (1, data_dimension) + tuple(reversed(lattice_itk)), dtype=dtype, device=device
+    )
+    current_lattice = lattice_itk
+    for level in range(number_of_fitting_levels):
+        # The scattered points' parametric *locations* never change across
+        # levels, but their u-coordinates do: ``_parametric_to_u``'s mapping
+        # depends on ``spans = lattice_size - 3``, which grows every
+        # refined level, so u must be recomputed per level, not cached.
+        parametric_u = tuple(
+            _parametric_to_u(
+                parametric_data[:, d], origin[d], spacing[d], domain_size[d], current_lattice[d], closed_axes[d]
+            )
+            for d in range(parametric_dimension)
+        )
+        geometry = _bspline_fit_geometry_points(parametric_u, current_lattice, closed_axes, eps)
+        reconstruction_flat = _evaluate_bspline_at_points(accumulated_coefficients, geometry).reshape(
+            data_dimension, point_count
+        )
+        residual_flat = values_flat - reconstruction_flat
+        fit_context = _bspline_fit_context(weight_flat, geometry, stable_accumulation)
+        update_flat = _bspline_fit_solve(residual_flat, weight_flat, fit_context, eps)
+        accumulated_coefficients = accumulated_coefficients + update_flat.reshape(
+            (1, data_dimension) + tuple(reversed(current_lattice))
+        )
+        if level + 1 < number_of_fitting_levels:
+            accumulated_coefficients = refine_bspline_coefficients(accumulated_coefficients)
+            current_lattice = tuple(2 * v - 3 for v in current_lattice)
+
+    domain = BSplineDomain(size=domain_size, spacing=spacing, origin=origin)
+    dense = synthesize_bspline_velocity(accumulated_coefficients, domain, closed=closed_axes)
+    if return_coefficients:
+        return dense, accumulated_coefficients
+    return dense
+
+
+def fit_bspline_displacement_field(
+    displacement_field: Optional[Tensor] = None,
+    displacement_weight_image: Optional[Tensor] = None,
+    displacement_origins=None,
+    displacements=None,
+    displacement_weights=None,
+    domain: Optional[BSplineDomain] = None,
+    number_of_fitting_levels: int = 4,
+    mesh_size: Union[int, Sequence[int]] = 1,
+    spline_order: int = 3,
+    enforce_stationary_boundary: bool = True,
+    *,
+    eps: float = 1e-6,
+    stable_accumulation: Optional[bool] = None,
+    return_coefficients: bool = False,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    """Fit and smooth a displacement field with cubic B-splines, from a
+    dense field, scattered displacement points, or both together -- a
+    PyTorch analogue of ANTsPy's ``fit_bspline_displacement_field`` (a
+    wrapper for ``itkDisplacementFieldToBSplineImageFilter``, itself built
+    on the same scattered-data filter as
+    :func:`fit_bspline_object_to_scattered_data`).
+
+    ``displacement_field`` (if given) is dense, shape ``(1, D, *spatial)``
+    matching ``domain`` (``D`` = spatial dimension); every voxel becomes one
+    weighted observation (weight 1, or ``displacement_weight_image``'s value
+    at that voxel). ``displacement_origins``/``displacements`` (if given)
+    are ``(P, D)`` scattered points with independent physical locations
+    (not necessarily on the field's grid), each individually weighted by
+    ``displacement_weights``. Both sources, when given together, are fit
+    jointly in one pass -- their contributions to the underlying B-spline
+    normal equations are simply combined (see
+    ``_concat_bspline_fit_geometries``) before solving.
+
+    Differences from ANTsPy, by design:
+
+    * ``domain`` (this package's ``BSplineDomain``) replaces ANTsPy's
+      separate ``origin``/``spacing``/``size``/``direction`` arguments.
+    * ``estimate_inverse`` is not implemented: ITK's inverse-field
+      estimation is a materially different, iterative algorithm, out of
+      scope here.
+    * ``rasterize_points`` is not applicable -- this implementation is
+      already fully vectorized rather than looping over points.
+    * ``enforce_stationary_boundary`` zeros the reconstructed field's
+      outermost voxel layer directly (``synthesize_bspline_velocity``'s
+      ``stationary_boundary`` option) rather than ITK's approach of adding
+      high-weight zero observations *during* the fit -- a documented
+      simplification, not a numerically identical reproduction. With a
+      coarse ``mesh_size`` the two approaches can disagree well beyond the
+      boundary voxels themselves: ITK's synthetic zero observations are
+      still just points fit like any other, so with few control points
+      (wide basis support) they pull the *whole* coefficient lattice
+      towards zero, not just its edge. Set ``enforce_stationary_boundary=
+      False`` when validating the fit itself against ANTsPy -- the two
+      agree to float precision in that case (see
+      ``test_bspline_scattered_data.py``).
+
+    Returns a dense tensor, shape ``(1, D, *domain.torch_size)``. Pass
+    ``return_coefficients=True`` to additionally get the raw coefficient
+    lattice.
+    """
+    if spline_order != 3:
+        raise NotImplementedError("only cubic B-splines (spline_order=3) are currently supported")
+    if displacement_field is None and (displacement_origins is None or displacements is None):
+        raise ValueError(
+            "Either displacement_field or scattered points (displacement_origins + "
+            "displacements) must be specified."
+        )
+
+    if displacement_field is not None:
+        if displacement_field.ndim not in (4, 5):
+            raise ValueError("displacement_field must be (1, D, *spatial)")
+        if displacement_field.shape[0] != 1:
+            raise ValueError("fit_bspline_displacement_field fits one field at a time (batch size 1)")
+        dimension = displacement_field.ndim - 2
+        if displacement_field.shape[1] != dimension:
+            raise ValueError("displacement_field must have one channel per spatial dimension")
+        domain = domain or BSplineDomain(tuple(reversed(displacement_field.shape[2:])))
+        if domain.torch_size != tuple(displacement_field.shape[2:]):
+            raise ValueError("displacement_field shape does not match domain")
+        device, dtype = displacement_field.device, displacement_field.dtype
+    else:
+        if domain is None:
+            raise ValueError("domain must be specified when fitting from scattered points only")
+        dimension = domain.dimension
+        origins_tensor = torch.as_tensor(displacement_origins)
+        device, dtype = origins_tensor.device, (
+            origins_tensor.dtype if origins_tensor.is_floating_point() else torch.float32
+        )
+
+    closed_axes = _as_bools(False, dimension)
+    lattice_itk = _mesh_size_to_lattice(mesh_size, dimension, spline_order, closed_axes)
+    if stable_accumulation is None:
+        stable_accumulation = device.type == "mps"
+
+    geometries = []
+    values_parts = []
+    weight_parts = []
+
+    if displacement_field is not None:
+        if displacement_weight_image is None:
+            weight_field = displacement_field.new_ones((1, 1) + displacement_field.shape[2:])
+        else:
+            if tuple(displacement_weight_image.shape[2:]) != tuple(displacement_field.shape[2:]):
+                raise ValueError("displacement_weight_image shape does not match displacement_field")
+            weight_field = displacement_weight_image.to(dtype=dtype, device=device)
+        grid_geometry = _bspline_fit_geometry(domain.torch_size, lattice_itk, dtype, device, eps)
+        grid_point_count = grid_geometry[0].shape[1]
+        geometries.append(grid_geometry)
+        values_parts.append(displacement_field.reshape(dimension, -1))
+        weight_parts.append(weight_field.reshape(1, -1).expand(dimension, grid_point_count))
+
+    if displacement_origins is not None:
+        origins = torch.as_tensor(displacement_origins, dtype=dtype, device=device)
+        values = torch.as_tensor(displacements, dtype=dtype, device=device)
+        if origins.ndim != 2 or origins.shape[1] != dimension:
+            raise ValueError(f"displacement_origins must be (P, {dimension})")
+        if values.shape != origins.shape:
+            raise ValueError("displacements must have the same shape as displacement_origins")
+        point_count = origins.shape[0]
+        if displacement_weights is None:
+            point_weights = origins.new_ones(point_count)
+        else:
+            point_weights = torch.as_tensor(displacement_weights, dtype=dtype, device=device).reshape(-1)
+            if point_weights.shape[0] != point_count:
+                raise ValueError("displacement_weights must have one value per point")
+        # origins are physical points in the *original* (unshrunk, ITK x,y[,z]
+        # ordered) domain; domain.size/spacing/origin describe that same
+        # physical domain, so this is exactly the same origin/spacing mapping
+        # ``fit_bspline_object_to_scattered_data`` uses.
+        parametric_u = tuple(
+            _parametric_to_u(
+                origins[:, d], domain.origin[d], domain.spacing[d], domain.size[d], lattice_itk[d], False
+            )
+            for d in range(dimension)
+        )
+        point_geometry = _bspline_fit_geometry_points(parametric_u, lattice_itk, closed_axes, eps)
+        geometries.append(point_geometry)
+        values_parts.append(values.t())
+        weight_parts.append(point_weights.unsqueeze(0).expand(dimension, -1))
+
+    geometry = geometries[0] if len(geometries) == 1 else _concat_bspline_fit_geometries(geometries)
+    values_flat = torch.cat(values_parts, dim=1)
+    weight_flat = torch.cat(weight_parts, dim=1)
+
+    accumulated_coefficients = torch.zeros(
+        (1, dimension) + tuple(reversed(lattice_itk)), dtype=dtype, device=device
+    )
+    current_lattice = lattice_itk
+    current_geometry = geometry
+    for level in range(number_of_fitting_levels):
+        if level > 0:
+            # Later levels need fresh geometry at the refined resolution;
+            # only the first level's geometry was built above.
+            parts = []
+            if displacement_field is not None:
+                parts.append(_bspline_fit_geometry(domain.torch_size, current_lattice, dtype, device, eps))
+            if displacement_origins is not None:
+                u_current = tuple(
+                    _parametric_to_u(
+                        origins[:, d],
+                        domain.origin[d],
+                        domain.spacing[d],
+                        domain.size[d],
+                        current_lattice[d],
+                        False,
+                    )
+                    for d in range(dimension)
+                )
+                parts.append(_bspline_fit_geometry_points(u_current, current_lattice, closed_axes, eps))
+            current_geometry = parts[0] if len(parts) == 1 else _concat_bspline_fit_geometries(parts)
+
+        reconstruction_flat = _evaluate_from_mixed_geometry(
+            accumulated_coefficients, current_geometry, displacement_field is not None, domain, dimension
+        )
+        residual_flat = values_flat - reconstruction_flat
+        fit_context = _bspline_fit_context(weight_flat, current_geometry, stable_accumulation)
+        update_flat = _bspline_fit_solve(residual_flat, weight_flat, fit_context, eps)
+        accumulated_coefficients = accumulated_coefficients + update_flat.reshape(
+            (1, dimension) + tuple(reversed(current_lattice))
+        )
+        if level + 1 < number_of_fitting_levels:
+            accumulated_coefficients = refine_bspline_coefficients(accumulated_coefficients)
+            current_lattice = tuple(2 * v - 3 for v in current_lattice)
+
+    dense = synthesize_bspline_velocity(
+        accumulated_coefficients, domain, stationary_boundary=enforce_stationary_boundary
+    )
+    if return_coefficients:
+        return dense, accumulated_coefficients
+    return dense
+
+
+def _evaluate_from_mixed_geometry(coefficients, geometry, has_grid, domain, dimension):
+    """``_evaluate_bspline_at_points`` doesn't care whether ``geometry`` came
+    from a dense grid, scattered points, or a concatenation of both -- it
+    only uses ``indices``/``basis_values``, which are already merged by
+    ``_concat_bspline_fit_geometries`` when needed. This thin wrapper exists
+    only for a descriptive call site in ``fit_bspline_displacement_field``.
+    """
+    return _evaluate_bspline_at_points(coefficients, geometry).reshape(dimension, -1)

--- a/antstorch/bspline_flow/bspline_synthesis.py
+++ b/antstorch/bspline_flow/bspline_synthesis.py
@@ -164,6 +164,268 @@ def synthesize_bspline_velocity(
     return output
 
 
+def _bspline_fit_geometry(
+    sample_shape: Sequence[int],
+    lattice_itk: Sequence[int],
+    dtype: torch.dtype,
+    device: torch.device,
+    eps: float,
+):
+    """Support-point indices/weights for one B-spline scattered-data update.
+
+    ``sample_shape`` is a regular dense grid's spatial shape, in PyTorch
+    order. This only depends on geometry (shapes and the lattice
+    resolution), never on sample values, so callers with an iterative loop
+    (e.g. N4) should compute it once per lattice resolution and reuse it
+    across iterations rather than rebuilding it every time.
+    """
+    dimension = len(lattice_itk)
+    if any(size < 2 for size in sample_shape):
+        raise ValueError(
+            "a fitting dimension has fewer than 2 samples "
+            f"{tuple(sample_shape)}; scattered-data fitting needs at least 2."
+        )
+    torch_coordinates = torch.meshgrid(
+        *[torch.arange(n, device=device) for n in sample_shape], indexing="ij"
+    )
+    itk_coordinates = tuple(reversed(torch_coordinates))
+
+    neighbors, basis = [], []
+    for coordinate, dense_size, lattice_size in zip(
+        itk_coordinates, tuple(reversed(sample_shape)), lattice_itk
+    ):
+        spans = lattice_size - 3
+        u = coordinate.to(dtype) * (float(spans) / float(dense_size - 1))
+        u = u.clamp_max(torch.nextafter(u.new_tensor(float(spans)), u.new_tensor(float("-inf"))))
+        base = torch.floor(u).to(torch.long)
+        local = torch.arange(4, device=device)
+        index = base[..., None] + local
+        neighbors.append(index)
+        basis.append(cubic_bspline_basis(u[..., None] - index.to(u.dtype) + 1.0))
+
+    support_indices, support_basis = [], []
+    strides, stride = [], 1
+    for size in lattice_itk:
+        strides.append(stride)
+        stride *= size
+    for support in product(range(4), repeat=dimension):
+        index = sum(neighbors[d][..., support[d]] * strides[d] for d in range(dimension))
+        value = torch.ones(sample_shape, dtype=dtype, device=device)
+        for d in range(dimension):
+            value = value * basis[d][..., support[d]]
+        support_indices.append(index.flatten())
+        support_basis.append(value.flatten())
+
+    indices = torch.stack(support_indices)
+    basis_values = torch.stack(support_basis)
+    squared_sum = basis_values.square().sum(dim=0).clamp_min(eps)
+    coefficient_count = stride
+    return indices, basis_values, squared_sum, coefficient_count
+
+
+def _bspline_fit_context(weight_flat: Tensor, geometry, stable_accumulation: bool):
+    """Precompute the value-independent half of the scattered-data update.
+
+    ``omega`` (the normal-equation weight accumulator) depends only on the
+    fit weights and the B-spline geometry -- never on the values being fit --
+    so it is identical across repeated fits at the same lattice resolution
+    with the same weights. Computing it once here instead of on every fit
+    removes the single largest redundant cost for iterative callers (an
+    unordered/one-hot reduction over every sample and every one of the
+    ``4**D`` local support points). It also matters most on MPS, where the
+    chunked one-hot reduction used for stability is the most expensive step.
+    """
+    indices, basis_values, squared_sum, coefficient_count = geometry
+    batch_channels = weight_flat.shape[0]
+    omega = weight_flat.new_zeros((batch_channels, coefficient_count))
+    support_count, sample_count = indices.shape
+    if stable_accumulation:
+        # Avoid MPS atomic scatter reductions. Chunked one-hot support
+        # matrices are reduced in a fixed order and accumulated with matrix
+        # products. The chunk-wise ``delta_basis`` factors are geometry-only
+        # and are cached for reuse by every fit's solve step.
+        max_one_hot_elements = 8_000_000
+        sample_chunk = max(1, max_one_hot_elements // (support_count * coefficient_count))
+        coefficient_axis = torch.arange(coefficient_count, device=indices.device)
+        chunks = []
+        for begin in range(0, sample_count, sample_chunk):
+            end = min(begin + sample_chunk, sample_count)
+            chunk_indices = indices[:, begin:end].transpose(0, 1)
+            chunk_basis = basis_values[:, begin:end].transpose(0, 1)
+            assignment = (chunk_indices[..., None] == coefficient_axis).to(basis_values.dtype)
+            omega_basis = (assignment * chunk_basis.square().unsqueeze(-1)).sum(dim=1)
+            delta_basis = (
+                assignment * (chunk_basis.pow(3) / squared_sum[begin:end, None]).unsqueeze(-1)
+            ).sum(dim=1)
+            omega = omega + weight_flat[:, begin:end] @ omega_basis
+            chunks.append((begin, end, delta_basis))
+        return {"mode": "stable", "chunks": chunks, "omega": omega}
+    else:
+        # A single vectorized scatter per statistic replaces 4**D kernel
+        # launches while preserving the sparse ITK update formula. Sample
+        # chunking bounds peak memory for large (e.g. shrink_factor=1 3-D)
+        # volumes instead of materializing one (batch*support*sample) tensor.
+        max_scatter_elements = 32_000_000
+        sample_chunk = max(1, max_scatter_elements // (batch_channels * support_count))
+        cubed_over_squared_sum = basis_values.pow(3) / squared_sum[None]
+        for begin in range(0, sample_count, sample_chunk):
+            end = min(begin + sample_chunk, sample_count)
+            expanded_indices = indices[:, begin:end].reshape(-1)[None].expand(batch_channels, -1)
+            omega_values = weight_flat[:, None, begin:end] * basis_values[:, begin:end].square()[None]
+            omega.scatter_add_(1, expanded_indices, omega_values.reshape(batch_channels, -1))
+        return {
+            "mode": "vectorized",
+            "omega": omega,
+            "indices": indices,
+            "cubed_over_squared_sum": cubed_over_squared_sum,
+            "sample_chunk": sample_chunk,
+        }
+
+
+def _bspline_fit_solve(residual_flat: Tensor, weight_flat: Tensor, context: dict, eps: float) -> Tensor:
+    """Per-call scattered-data update given a resolution-fixed context."""
+    batch_channels = residual_flat.shape[0]
+    omega = context["omega"]
+    delta = residual_flat.new_zeros(omega.shape)
+    if context["mode"] == "stable":
+        for begin, end, delta_basis in context["chunks"]:
+            delta = delta + (residual_flat[:, begin:end] * weight_flat[:, begin:end]) @ delta_basis
+    else:
+        indices = context["indices"]
+        cubed_over_squared_sum = context["cubed_over_squared_sum"]
+        sample_chunk = context["sample_chunk"]
+        sample_count = residual_flat.shape[1]
+        for begin in range(0, sample_count, sample_chunk):
+            end = min(begin + sample_chunk, sample_count)
+            expanded_indices = indices[:, begin:end].reshape(-1)[None].expand(batch_channels, -1)
+            delta_values = (
+                residual_flat[:, None, begin:end]
+                * weight_flat[:, None, begin:end]
+                * cubed_over_squared_sum[None, :, begin:end]
+            )
+            delta.scatter_add_(1, expanded_indices, delta_values.reshape(batch_channels, -1))
+    return torch.where(omega > eps, delta / omega.clamp_min(eps), torch.zeros_like(delta))
+
+
+def _refine_bspline_coefficients_1d(coefficients: Tensor, dim: int) -> Tensor:
+    """Exact dyadic refinement of a uniform cubic B-spline lattice along one
+    axis: ``K`` control points become ``2*K - 3``, representing the
+    identical piecewise-cubic function at a finer control-point resolution
+    (uniform cubic knot insertion / Lane-Riesenfeld subdivision). Derived
+    from ITK's Cox-de-Boor shape functions
+    (``itkCoxDeBoorBSplineKernelFunction``) and refinement matrix
+    (``itkBSplineControlPointImageFilter::RefineControlPointLattice``), and
+    independently verified against this package's own already-validated
+    ``cubic_bspline_basis`` to floating-point-level agreement (~4e-10 max
+    difference). No special boundary handling is required for an open
+    (non-periodic) axis: every index referenced below stays in bounds for
+    any ``K >= 4``, the minimum lattice size this package allows.
+    """
+    k_old = coefficients.shape[dim]
+    if k_old < 4:
+        raise ValueError("cubic B-spline refinement requires at least four control points")
+    even = 0.5 * (coefficients.narrow(dim, 0, k_old - 1) + coefficients.narrow(dim, 1, k_old - 1))
+    odd = (
+        coefficients.narrow(dim, 0, k_old - 2)
+        + 6.0 * coefficients.narrow(dim, 1, k_old - 2)
+        + coefficients.narrow(dim, 2, k_old - 2)
+    ) / 8.0
+    interleaved = torch.stack([even.narrow(dim, 0, k_old - 2), odd], dim=dim + 1).flatten(dim, dim + 1)
+    return torch.cat([interleaved, even.narrow(dim, k_old - 2, 1)], dim=dim)
+
+
+def refine_bspline_coefficients(coefficients: Tensor) -> Tensor:
+    """Refine every spatial axis of a coefficient lattice (``K -> 2*K - 3``
+    per axis), reproducing the identical dense field at the finer
+    resolution -- see ``_refine_bspline_coefficients_1d``. This is what
+    lets a running coefficient lattice be carried, refined, and continued
+    across a multi-resolution fit exactly as ITK's own
+    ``m_LogBiasFieldControlPointLattice``/``m_PsiLattice`` are (see
+    ``n4_bias_field_correction`` and ``fit_bspline_object_to_scattered_data``
+    for two different callers of this same primitive).
+    """
+    refined = coefficients
+    for dim in range(2, coefficients.ndim):
+        refined = _refine_bspline_coefficients_1d(refined, dim)
+    return refined
+
+
+def fit_bspline_coefficients(
+    values: Tensor,
+    domain: BSplineDomain,
+    lattice_size: Sequence[int],
+    weights: Optional[Tensor] = None,
+    *,
+    stable_accumulation: Optional[bool] = None,
+    eps: float = 1e-6,
+) -> Tensor:
+    """One-shot scattered-data cubic B-spline coefficient fit on a regular
+    dense grid -- the complementary "inverse" of
+    :func:`synthesize_bspline_velocity` (dense field -> coefficients,
+    instead of coefficients -> dense field). This is ITK's
+    ``BSplineScatteredDataPointSetToImageFilter`` single-level (non-
+    iterative) local least-squares approximation:
+
+    .. code-block:: text
+
+        omega += weight * B**2
+        delta  += value * weight * B**3 / sum(B**2)
+        coefficient = delta / omega        (0 where omega <= eps)
+
+    ``values`` has shape ``(N, C, *domain.torch_size)``: the dense samples
+    to approximate. ``lattice_size`` is the number of control points per
+    axis in ITK ``(x, y[, z])`` order (at least 4 per axis -- the same
+    convention as every coefficient tensor in this package). ``weights``
+    defaults to a uniform weight of 1 and otherwise must be broadcastable to
+    ``values``' shape (e.g. a mask or confidence map).
+
+    Returns coefficients with shape ``(N, C, *reversed(lattice_size))``,
+    directly usable with :func:`synthesize_bspline_velocity` (optionally at
+    a *different* resolution or domain than ``values`` was fit from -- the
+    coefficients describe a continuous B-spline surface, independent of any
+    particular sampling grid).
+
+    This performs one independent fit; it does not implement ITK's
+    multi-level scattered-data refinement, and only open (non-periodic)
+    lattices are supported. ``n4_bias_field_correction`` builds on the same
+    underlying ``_bspline_fit_geometry``/``_bspline_fit_context``/
+    ``_bspline_fit_solve`` primitives directly rather than through this
+    wrapper, since its iterative loop needs to reuse the same geometry and
+    ``omega`` across many fits at a fixed lattice resolution -- exactly the
+    per-call recomputation this convenience wrapper is unsuitable for in a
+    tight loop.
+    """
+    if not isinstance(domain, BSplineDomain):
+        raise TypeError("domain must be a BSplineDomain")
+    if values.ndim != domain.dimension + 2:
+        raise ValueError(f"expected {domain.dimension + 2}-D values")
+    if not values.is_floating_point():
+        raise TypeError("values must have a floating-point dtype")
+    if tuple(values.shape[2:]) != domain.torch_size:
+        raise ValueError("values shape does not match domain")
+    lattice_itk = tuple(int(k) for k in lattice_size)
+    if len(lattice_itk) != domain.dimension:
+        raise ValueError(f"lattice_size must have {domain.dimension} values")
+    if any(k < 4 for k in lattice_itk):
+        raise ValueError("cubic fitting requires at least four control points per dimension")
+
+    if weights is None:
+        weight_tensor = values.new_ones(values.shape)
+    else:
+        weight_tensor = weights.to(dtype=values.dtype, device=values.device).expand_as(values)
+    if stable_accumulation is None:
+        stable_accumulation = values.device.type == "mps"
+
+    batch_channels = values.shape[0] * values.shape[1]
+    values_flat = values.reshape(batch_channels, -1)
+    weight_flat = weight_tensor.reshape(batch_channels, -1)
+
+    geometry = _bspline_fit_geometry(domain.torch_size, lattice_itk, values.dtype, values.device, eps)
+    context = _bspline_fit_context(weight_flat, geometry, stable_accumulation)
+    coefficients = _bspline_fit_solve(values_flat, weight_flat, context, eps)
+    return coefficients.reshape((values.shape[0], values.shape[1]) + tuple(reversed(lattice_itk)))
+
+
 class CubicBSplineSynthesis(nn.Module):
     """``nn.Module`` wrapper around :func:`synthesize_bspline_velocity`."""
 

--- a/antstorch/bspline_flow/n4_bias_field_correction.py
+++ b/antstorch/bspline_flow/n4_bias_field_correction.py
@@ -6,15 +6,20 @@ image tensors are ``(N, C, H, W)`` or ``(N, C, D, H, W)``. Bias fields are
 scalar and dimensionless in log-intensity space.
 """
 
-from itertools import product
 from math import ceil, log2
-from typing import Optional, Sequence, Union
+from typing import Optional, Union
 
 import torch
 from torch import Tensor, nn
 
 from .bspline_domain import BSplineDomain
-from .bspline_synthesis import cubic_bspline_basis, synthesize_bspline_velocity
+from .bspline_synthesis import (
+    _bspline_fit_context,
+    _bspline_fit_geometry,
+    _bspline_fit_solve,
+    refine_bspline_coefficients,
+    synthesize_bspline_velocity,
+)
 
 
 def _expand_like_image(value: Optional[Tensor], image: Tensor, name: str, default: float) -> Tensor:
@@ -153,13 +158,25 @@ def _shrunk_domain(domain: BSplineDomain, shrink_factor: int) -> BSplineDomain:
     the shrunk sample count while the per-iteration dense update was
     synthesized over the *full-resolution* domain's sample count: two
     different mappings of the same physical mesh, increasingly mismatched at
-    finer mesh levels, which was the actual root cause of the divergence
-    observed at N4's default 4-level/50-iteration setting on real image
-    data (as opposed to missing coefficient-lattice refinement between
-    levels, which -- see ``_refine_bspline_coefficients`` -- turns out to be
-    mathematically unnecessary for correctness by itself, though it is still
-    implemented below for architectural fidelity with ITK and to give the
-    final reconstruction step an explicit coefficient lattice to consume).
+    finer mesh levels. That was A root cause of divergence at N4's default
+    4-level/50-iteration setting -- but NOT the only one. Measured directly
+    against ANTsPy (see ``tools/compare_n4_bias_field_correction.py``),
+    normalized log-bias MAE still grows with the number of fitting levels
+    even after this fix, holding total iteration count roughly fixed
+    (0.041 at 1 level -> 0.060 at 2 -> 0.105 at 3 -> 0.136 at 4, on ``r16``).
+    A control experiment -- fitting directly at the finest level's control
+    point count in a single level/pass, instead of ramping up through the
+    coarser levels first -- gives a *smaller* MAE (0.039) than the 4-level
+    ramp (0.136), at the same final resolution. So besides fine meshes
+    being inherently more sensitive to small cross-implementation numeric
+    differences (which alone explains part of the growth), the coarse-to-
+    fine multi-level progression itself appears to add further drift beyond
+    what fitting the fine mesh directly would produce. This is not yet
+    isolated to a specific line of code -- see the project notes for
+    2026-08-18 for the measurements above; a claim in an earlier revision
+    of this docstring that lattice refinement was "mathematically
+    unnecessary for correctness" was premature and is retracted pending
+    that investigation.
     """
     shrunk_size = tuple(size // shrink_factor for size in domain.size)
     if any(size < 2 for size in shrunk_size):
@@ -178,191 +195,6 @@ def _shrunk_domain(domain: BSplineDomain, shrink_factor: int) -> BSplineDomain:
         for i in range(domain.dimension)
     )
     return BSplineDomain(size=shrunk_size, spacing=shrunk_spacing, origin=origin, direction=domain.direction)
-
-
-def _bspline_fit_geometry(
-    sample_shape: Sequence[int],
-    lattice_itk: Sequence[int],
-    dtype: torch.dtype,
-    device: torch.device,
-    eps: float,
-):
-    """Support-point indices/weights for one B-spline scattered-data update.
-
-    ``sample_shape`` is the already-shrunk spatial shape, in PyTorch order.
-    This only depends on geometry (shapes and the lattice resolution), never
-    on image intensities, so it is computed once per refinement level and
-    reused for every convergence iteration at that level rather than being
-    rebuilt on every iteration.
-    """
-    dimension = len(lattice_itk)
-    if any(size < 2 for size in sample_shape):
-        raise ValueError(
-            "shrink_factor is too large for this image: a shrunk spatial "
-            f"dimension has fewer than 2 samples {tuple(sample_shape)}; "
-            "use a smaller shrink_factor."
-        )
-    torch_coordinates = torch.meshgrid(
-        *[torch.arange(n, device=device) for n in sample_shape], indexing="ij"
-    )
-    itk_coordinates = tuple(reversed(torch_coordinates))
-
-    neighbors, basis = [], []
-    for coordinate, dense_size, lattice_size in zip(
-        itk_coordinates, tuple(reversed(sample_shape)), lattice_itk
-    ):
-        spans = lattice_size - 3
-        u = coordinate.to(dtype) * (float(spans) / float(dense_size - 1))
-        u = u.clamp_max(torch.nextafter(u.new_tensor(float(spans)), u.new_tensor(float("-inf"))))
-        base = torch.floor(u).to(torch.long)
-        local = torch.arange(4, device=device)
-        index = base[..., None] + local
-        neighbors.append(index)
-        basis.append(cubic_bspline_basis(u[..., None] - index.to(u.dtype) + 1.0))
-
-    support_indices, support_basis = [], []
-    strides, stride = [], 1
-    for size in lattice_itk:
-        strides.append(stride)
-        stride *= size
-    for support in product(range(4), repeat=dimension):
-        index = sum(neighbors[d][..., support[d]] * strides[d] for d in range(dimension))
-        value = torch.ones(sample_shape, dtype=dtype, device=device)
-        for d in range(dimension):
-            value = value * basis[d][..., support[d]]
-        support_indices.append(index.flatten())
-        support_basis.append(value.flatten())
-
-    indices = torch.stack(support_indices)
-    basis_values = torch.stack(support_basis)
-    squared_sum = basis_values.square().sum(dim=0).clamp_min(eps)
-    coefficient_count = stride
-    return indices, basis_values, squared_sum, coefficient_count
-
-
-def _bspline_fit_context(weight_flat: Tensor, geometry, stable_accumulation: bool):
-    """Precompute the residual-independent half of the scattered-data update.
-
-    ``omega`` (the normal-equation weight accumulator) depends only on the
-    fit weights and the B-spline geometry -- never on the current residual --
-    so it is identical on every convergence iteration within a level.
-    Computing it once here, instead of on every iteration, removes the
-    single largest redundant cost of the original per-iteration
-    implementation (an unordered/one-hot reduction over every sample and
-    every one of the ``4**D`` local support points). It also matters most on
-    MPS, where the chunked one-hot reduction used for stability is the most
-    expensive step in the whole N4 loop.
-    """
-    indices, basis_values, squared_sum, coefficient_count = geometry
-    batch_channels = weight_flat.shape[0]
-    omega = weight_flat.new_zeros((batch_channels, coefficient_count))
-    support_count, sample_count = indices.shape
-    if stable_accumulation:
-        # Avoid MPS atomic scatter reductions. Chunked one-hot support
-        # matrices are reduced in a fixed order and accumulated with matrix
-        # products. The chunk-wise ``delta_basis`` factors are geometry-only
-        # and are cached for reuse by every iteration's solve step.
-        max_one_hot_elements = 8_000_000
-        sample_chunk = max(1, max_one_hot_elements // (support_count * coefficient_count))
-        coefficient_axis = torch.arange(coefficient_count, device=indices.device)
-        chunks = []
-        for begin in range(0, sample_count, sample_chunk):
-            end = min(begin + sample_chunk, sample_count)
-            chunk_indices = indices[:, begin:end].transpose(0, 1)
-            chunk_basis = basis_values[:, begin:end].transpose(0, 1)
-            assignment = (chunk_indices[..., None] == coefficient_axis).to(basis_values.dtype)
-            omega_basis = (assignment * chunk_basis.square().unsqueeze(-1)).sum(dim=1)
-            delta_basis = (
-                assignment * (chunk_basis.pow(3) / squared_sum[begin:end, None]).unsqueeze(-1)
-            ).sum(dim=1)
-            omega = omega + weight_flat[:, begin:end] @ omega_basis
-            chunks.append((begin, end, delta_basis))
-        return {"mode": "stable", "chunks": chunks, "omega": omega}
-    else:
-        # A single vectorized scatter per statistic replaces 4**D kernel
-        # launches while preserving the sparse ITK update formula. Sample
-        # chunking bounds peak memory for large (e.g. shrink_factor=1 3-D)
-        # volumes instead of materializing one (batch*support*sample) tensor.
-        max_scatter_elements = 32_000_000
-        sample_chunk = max(1, max_scatter_elements // (batch_channels * support_count))
-        cubed_over_squared_sum = basis_values.pow(3) / squared_sum[None]
-        for begin in range(0, sample_count, sample_chunk):
-            end = min(begin + sample_chunk, sample_count)
-            expanded_indices = indices[:, begin:end].reshape(-1)[None].expand(batch_channels, -1)
-            omega_values = weight_flat[:, None, begin:end] * basis_values[:, begin:end].square()[None]
-            omega.scatter_add_(1, expanded_indices, omega_values.reshape(batch_channels, -1))
-        return {
-            "mode": "vectorized",
-            "omega": omega,
-            "indices": indices,
-            "cubed_over_squared_sum": cubed_over_squared_sum,
-            "sample_chunk": sample_chunk,
-        }
-
-
-def _bspline_fit_solve(residual_flat: Tensor, weight_flat: Tensor, context: dict, eps: float) -> Tensor:
-    """Per-iteration scattered-data update given a level-fixed context."""
-    batch_channels = residual_flat.shape[0]
-    omega = context["omega"]
-    delta = residual_flat.new_zeros(omega.shape)
-    if context["mode"] == "stable":
-        for begin, end, delta_basis in context["chunks"]:
-            delta = delta + (residual_flat[:, begin:end] * weight_flat[:, begin:end]) @ delta_basis
-    else:
-        indices = context["indices"]
-        cubed_over_squared_sum = context["cubed_over_squared_sum"]
-        sample_chunk = context["sample_chunk"]
-        sample_count = residual_flat.shape[1]
-        for begin in range(0, sample_count, sample_chunk):
-            end = min(begin + sample_chunk, sample_count)
-            expanded_indices = indices[:, begin:end].reshape(-1)[None].expand(batch_channels, -1)
-            delta_values = (
-                residual_flat[:, None, begin:end]
-                * weight_flat[:, None, begin:end]
-                * cubed_over_squared_sum[None, :, begin:end]
-            )
-            delta.scatter_add_(1, expanded_indices, delta_values.reshape(batch_channels, -1))
-    return torch.where(omega > eps, delta / omega.clamp_min(eps), torch.zeros_like(delta))
-
-
-def _refine_bspline_coefficients_1d(coefficients: Tensor, dim: int) -> Tensor:
-    """Exact dyadic refinement of a uniform cubic B-spline lattice along one
-    axis: ``K`` control points become ``2*K - 3``, representing the
-    identical piecewise-cubic function at a finer control-point resolution
-    (uniform cubic knot insertion / Lane-Riesenfeld subdivision). Derived
-    from ITK's Cox-de-Boor shape functions
-    (``itkCoxDeBoorBSplineKernelFunction``) and refinement matrix
-    (``itkBSplineControlPointImageFilter::RefineControlPointLattice``), and
-    independently verified against this package's own already-validated
-    ``cubic_bspline_basis`` to floating-point-level agreement (~4e-10 max
-    difference). No special boundary handling is required for an open
-    (non-periodic) axis: every index referenced below stays in bounds for
-    any ``K >= 4``, the minimum lattice size this package allows.
-    """
-    k_old = coefficients.shape[dim]
-    if k_old < 4:
-        raise ValueError("cubic B-spline refinement requires at least four control points")
-    even = 0.5 * (coefficients.narrow(dim, 0, k_old - 1) + coefficients.narrow(dim, 1, k_old - 1))
-    odd = (
-        coefficients.narrow(dim, 0, k_old - 2)
-        + 6.0 * coefficients.narrow(dim, 1, k_old - 2)
-        + coefficients.narrow(dim, 2, k_old - 2)
-    ) / 8.0
-    interleaved = torch.stack([even.narrow(dim, 0, k_old - 2), odd], dim=dim + 1).flatten(dim, dim + 1)
-    return torch.cat([interleaved, even.narrow(dim, k_old - 2, 1)], dim=dim)
-
-
-def _refine_bspline_coefficients(coefficients: Tensor) -> Tensor:
-    """Refine every spatial axis of a coefficient lattice (``K -> 2*K - 3``
-    per axis), reproducing the identical dense field at the finer
-    resolution. This is what lets ``accumulated_coefficients`` be carried,
-    refined, and continued across N4's multi-resolution levels exactly as
-    ITK's ``m_LogBiasFieldControlPointLattice`` is.
-    """
-    refined = coefficients
-    for dim in range(2, coefficients.ndim):
-        refined = _refine_bspline_coefficients_1d(refined, dim)
-    return refined
 
 
 def _initial_lattice_size(domain: BSplineDomain, spline_param) -> tuple:
@@ -440,7 +272,12 @@ def n4_bias_field_correction(
     fit_slices = (slice(None), slice(None)) + _shrink_slices(image.shape[2:], shrink_factor)
     shrunk_domain = _shrunk_domain(domain, shrink_factor)
     positive_image = image.clamp_min(eps)
-    log_input = positive_image.log()[fit_slices]
+    # ITK's N4 filter takes the logarithm only for strictly positive
+    # intensities; zero and negative pixels retain their original values.
+    # In particular, mapping a zero-valued background to log(eps) would add
+    # a large artificial mode to the histogram when that background is
+    # included by the mask.
+    log_input = torch.where(image > 0, positive_image.log(), image)[fit_slices]
     included = included_full[fit_slices]
     fit_weights = fit_weights_full[fit_slices]
 
@@ -513,7 +350,7 @@ def n4_bias_field_correction(
             # item/channel without a device-to-host synchronization.
             active = active * (convergence_measurement > tolerance).to(image.dtype)
         if level + 1 < len(iterations):
-            accumulated_coefficients = _refine_bspline_coefficients(accumulated_coefficients)
+            accumulated_coefficients = refine_bspline_coefficients(accumulated_coefficients)
             lattice_itk = tuple(2 * value - 3 for value in lattice_itk)
 
     full_log_bias = synthesize_bspline_velocity(accumulated_coefficients, domain)

--- a/tests/bspline_flow/test_bspline_scattered_data.py
+++ b/tests/bspline_flow/test_bspline_scattered_data.py
@@ -1,0 +1,239 @@
+import numpy as np
+import pytest
+import torch
+
+from antstorch.bspline_flow import BSplineDomain, fit_bspline_coefficients
+from antstorch.bspline_flow.bspline_scattered_data import (
+    fit_bspline_displacement_field,
+    fit_bspline_object_to_scattered_data,
+)
+from antstorch.bspline_flow.bspline_synthesis import synthesize_bspline_velocity
+
+
+def test_single_level_scattered_fit_matches_dense_grid_fit():
+    # Fitting every pixel of a regular grid as an independent scattered
+    # point, at a single level, must reduce exactly to the already-validated
+    # dense-grid least-squares fit (`fit_bspline_coefficients`).
+    torch.manual_seed(0)
+    H, W = 11, 14
+    domain = BSplineDomain((W, H))
+    values = torch.rand(1, 1, H, W, dtype=torch.double)
+    lattice = (5, 6)
+
+    # `lattice` is ITK (x, y) order, matching fit_bspline_coefficients'
+    # convention -- mesh_size below must use the same axis order.
+    dense_coefficients = fit_bspline_coefficients(values, domain, lattice)
+    dense = synthesize_bspline_velocity(dense_coefficients, domain)
+
+    yy, xx = torch.meshgrid(torch.arange(H), torch.arange(W), indexing="ij")
+    scattered_data = values.reshape(-1, 1).to(torch.double)
+    parametric_data = torch.stack([xx.reshape(-1), yy.reshape(-1)], dim=1).to(torch.double)
+    scattered_dense, scattered_coefficients = fit_bspline_object_to_scattered_data(
+        scattered_data,
+        parametric_data,
+        parametric_domain_origin=[0.0, 0.0],
+        parametric_domain_spacing=[1.0, 1.0],
+        parametric_domain_size=[W, H],
+        number_of_fitting_levels=1,
+        mesh_size=(lattice[0] - 3, lattice[1] - 3),
+        dtype=torch.double,
+        return_coefficients=True,
+    )
+    torch.testing.assert_close(scattered_coefficients, dense_coefficients, rtol=1e-12, atol=1e-12)
+    torch.testing.assert_close(scattered_dense, dense, rtol=1e-12, atol=1e-12)
+
+
+def test_multi_level_fit_reduces_residual_each_level():
+    torch.manual_seed(3)
+    point_count = 400
+    parametric = torch.rand(point_count, 2, dtype=torch.double) * torch.tensor([29.0, 19.0])
+    scattered = torch.sin(parametric[:, :1] * 0.3) * torch.cos(parametric[:, 1:] * 0.2)
+
+    residuals = []
+    for levels in (1, 2, 3, 4, 5):
+        dense = fit_bspline_object_to_scattered_data(
+            scattered,
+            parametric,
+            parametric_domain_origin=[0.0, 0.0],
+            parametric_domain_spacing=[1.0, 1.0],
+            parametric_domain_size=[30, 20],
+            number_of_fitting_levels=levels,
+            mesh_size=1,
+            dtype=torch.double,
+        )
+        u = parametric[:, 0].round().long().clamp(0, 29)
+        v = parametric[:, 1].round().long().clamp(0, 19)
+        fitted_at_points = dense[0, 0, v, u]
+        residuals.append((scattered[:, 0] - fitted_at_points).square().mean().item())
+
+    for earlier, later in zip(residuals, residuals[1:]):
+        assert later <= earlier + 1e-9
+
+
+def test_fit_bspline_object_to_scattered_data_agrees_with_antspy_scalar():
+    ants = pytest.importorskip("ants")
+    rng = np.random.default_rng(42)
+    size_x, size_y = 40, 25
+    point_count = 800
+    scattered = rng.normal(size=(point_count, 1))
+    parametric = np.column_stack(
+        [rng.uniform(0, size_x - 1, point_count), rng.uniform(0, size_y - 1, point_count)]
+    )
+    weights = rng.uniform(0.5, 1.5, point_count)
+
+    kwargs = dict(
+        parametric_domain_origin=[0.0, 0.0],
+        parametric_domain_spacing=[1.0, 1.0],
+        parametric_domain_size=[size_x, size_y],
+        number_of_fitting_levels=4,
+        mesh_size=2,
+    )
+    ants_arr = ants.fit_bspline_object_to_scattered_data(scattered, parametric, data_weights=weights, **kwargs).numpy()
+    torch_arr = fit_bspline_object_to_scattered_data(
+        scattered, parametric, data_weights=weights, dtype=torch.float64, **kwargs
+    )[0, 0].numpy()
+
+    # See fit_bspline_object_to_scattered_data's docstring: this package's
+    # (N, C, *spatial) output is the ANTsPy/ITK array with a full axis
+    # reversal (`.T` in 2-D).
+    np.testing.assert_allclose(torch_arr.T, ants_arr, rtol=1e-3, atol=1e-3)
+
+
+def test_fit_bspline_object_to_scattered_data_agrees_with_antspy_vector():
+    ants = pytest.importorskip("ants")
+    rng = np.random.default_rng(7)
+    size = [60, 45]
+    point_count = 50
+    points = rng.uniform([5, 5], [54, 39], size=(point_count, 2))
+    deltas = rng.normal(size=(point_count, 2)) * 3.0
+
+    kwargs = dict(
+        parametric_domain_origin=[0.0, 0.0],
+        parametric_domain_spacing=[1.0, 1.0],
+        parametric_domain_size=size,
+        number_of_fitting_levels=3,
+        mesh_size=(1, 1),
+    )
+    ants_arr = ants.fit_bspline_object_to_scattered_data(deltas, points, **kwargs).numpy()
+    torch_arr = fit_bspline_object_to_scattered_data(deltas, points, dtype=torch.float64, **kwargs)[0].numpy()
+
+    np.testing.assert_allclose(torch_arr[0].T, ants_arr[..., 0], rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(torch_arr[1].T, ants_arr[..., 1], rtol=1e-3, atol=1e-3)
+
+
+def test_fit_bspline_displacement_field_from_points_agrees_with_antspy():
+    # enforce_stationary_boundary=False isolates the underlying fit itself
+    # from the (documented, intentionally different) boundary treatment --
+    # see the enforce_stationary_boundary note in the docstring.
+    ants = pytest.importorskip("ants")
+    rng = np.random.default_rng(7)
+    size = [60, 45]
+    point_count = 50
+    points = rng.uniform([5, 5], [54, 39], size=(point_count, 2))
+    deltas = rng.normal(size=(point_count, 2)) * 3.0
+
+    ants_arr = ants.fit_bspline_displacement_field(
+        displacement_origins=points,
+        displacements=deltas,
+        origin=[0.0, 0.0],
+        spacing=[1.0, 1.0],
+        size=size,
+        direction=np.eye(2),
+        number_of_fitting_levels=3,
+        mesh_size=(1, 1),
+        enforce_stationary_boundary=False,
+    ).numpy()
+
+    domain = BSplineDomain(size=size, spacing=(1.0, 1.0), origin=(0.0, 0.0))
+    torch_arr = fit_bspline_displacement_field(
+        displacement_origins=points,
+        displacements=deltas,
+        domain=domain,
+        number_of_fitting_levels=3,
+        mesh_size=(1, 1),
+        enforce_stationary_boundary=False,
+    )[0].numpy()
+
+    np.testing.assert_allclose(torch_arr[0].T, ants_arr[..., 0], rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(torch_arr[1].T, ants_arr[..., 1], rtol=1e-3, atol=1e-3)
+
+
+def test_fit_bspline_displacement_field_enforces_stationary_boundary():
+    torch.manual_seed(5)
+    domain = BSplineDomain((20, 16))
+    field = torch.randn(1, 2, *domain.torch_size, dtype=torch.double) * 0.1
+    fitted = fit_bspline_displacement_field(
+        displacement_field=field,
+        domain=domain,
+        number_of_fitting_levels=2,
+        mesh_size=1,
+        enforce_stationary_boundary=True,
+    )
+    assert torch.all(fitted[..., 0, :] == 0)
+    assert torch.all(fitted[..., -1, :] == 0)
+    assert torch.all(fitted[..., :, 0] == 0)
+    assert torch.all(fitted[..., :, -1] == 0)
+
+
+def test_fit_bspline_displacement_field_combines_grid_and_points():
+    torch.manual_seed(9)
+    domain = BSplineDomain((18, 15))
+    field = torch.randn(1, 2, *domain.torch_size, dtype=torch.double) * 0.05
+    points = torch.rand(10, 2, dtype=torch.double) * torch.tensor([17.0, 14.0])
+    deltas = torch.randn(10, 2, dtype=torch.double) * 0.2
+
+    combined = fit_bspline_displacement_field(
+        displacement_field=field,
+        displacement_origins=points,
+        displacements=deltas,
+        domain=domain,
+        number_of_fitting_levels=2,
+        mesh_size=1,
+    )
+    field_only = fit_bspline_displacement_field(
+        displacement_field=field, domain=domain, number_of_fitting_levels=2, mesh_size=1
+    )
+    assert torch.isfinite(combined).all()
+    assert not torch.allclose(combined, field_only)
+
+
+def test_fit_bspline_displacement_field_requires_field_or_points():
+    domain = BSplineDomain((10, 10))
+    with pytest.raises(ValueError):
+        fit_bspline_displacement_field(domain=domain)
+
+
+def test_fit_functions_reject_non_cubic_spline_order():
+    domain = BSplineDomain((10, 10))
+    field = torch.zeros(1, 2, *domain.torch_size)
+    with pytest.raises(NotImplementedError):
+        fit_bspline_displacement_field(displacement_field=field, domain=domain, spline_order=2)
+    with pytest.raises(NotImplementedError):
+        fit_bspline_object_to_scattered_data(
+            torch.zeros(5, 1),
+            torch.zeros(5, 2),
+            parametric_domain_origin=[0.0, 0.0],
+            parametric_domain_spacing=[1.0, 1.0],
+            parametric_domain_size=[10, 10],
+            spline_order=2,
+        )
+
+
+def test_gradients_flow_through_scattered_fit():
+    torch.manual_seed(2)
+    parametric = torch.rand(30, 2, dtype=torch.double) * torch.tensor([19.0, 14.0])
+    scattered = torch.randn(30, 1, dtype=torch.double, requires_grad=True)
+    dense = fit_bspline_object_to_scattered_data(
+        scattered,
+        parametric,
+        parametric_domain_origin=[0.0, 0.0],
+        parametric_domain_spacing=[1.0, 1.0],
+        parametric_domain_size=[20, 15],
+        number_of_fitting_levels=2,
+        mesh_size=1,
+        dtype=torch.double,
+    )
+    dense.sum().backward()
+    assert scattered.grad is not None
+    assert torch.isfinite(scattered.grad).all()
+    assert scattered.grad.abs().sum() > 0

--- a/tools/compare_bspline_scattered_data.py
+++ b/tools/compare_bspline_scattered_data.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Compare ANTs and differentiable ANTsTorch scattered-data B-spline fitting.
+
+Compares ``antstorch.fit_bspline_object_to_scattered_data`` and
+``antstorch.fit_bspline_displacement_field`` against their ANTsPy
+counterparts (``ants.fit_bspline_object_to_scattered_data`` /
+``ants.fit_bspline_displacement_field``), the same comparison methodology
+as ``tools/compare_n4_bias_field_correction.py``.
+
+Three independent comparisons run by default:
+
+1. ``fit_bspline_object_to_scattered_data`` on scalar data -- either an
+   image's own pixel grid (every pixel a point) or a random subsample of
+   it (genuinely scattered, off-grid points).
+2. ``fit_bspline_displacement_field`` from scattered displacement points
+   (random locations and random displacement vectors).
+3. ``fit_bspline_displacement_field`` from a dense displacement field
+   (best-effort: some ANTsPy builds do not export the underlying
+   ``fitBsplineDisplacementFieldD*`` library symbol for this input mode --
+   if so, this comparison is skipped with a clear message instead of
+   crashing the whole run).
+
+Both implementations return this package's ``(N, C, *reversed(size))``
+tensor convention, which is the ANTsPy/ITK array with every spatial axis
+reversed (see ``fit_bspline_object_to_scattered_data``'s docstring) --
+this script accounts for that before comparing.
+
+Examples
+--------
+Synthetic scattered data, no image or network access required::
+
+    python tools/compare_bspline_scattered_data.py
+
+Use the bundled 2-D ``r16`` image's pixel grid::
+
+    python tools/compare_bspline_scattered_data.py --image r16
+
+Use 2000 random (off-grid) pixels from an image as scattered points::
+
+    python tools/compare_bspline_scattered_data.py --image r16 --num-points 2000
+
+3-D synthetic data with a finer mesh and CUDA::
+
+    python tools/compare_bspline_scattered_data.py --dimension 3 --mesh-size 3 3 3 --device cuda
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import ants
+import numpy as np
+import torch
+
+import antstorch
+
+
+def reverse_axes(array: np.ndarray) -> np.ndarray:
+    """This package's ``(N, C, *reversed(size))`` convention <-> ANTsPy/ITK's
+    direct ``(size_x, size_y[, size_z])`` array order: a full reversal of
+    every spatial axis (``.T`` in 2-D; not a literal ``.T`` in 3-D). See
+    ``fit_bspline_object_to_scattered_data``'s docstring. Only valid for a
+    purely spatial (scalar) array -- use ``vector_to_ants_order`` for a
+    ``(D, *spatial)`` vector field, where the leading component axis must
+    NOT be reversed along with the spatial ones.
+    """
+    return np.ascontiguousarray(np.transpose(array, tuple(range(array.ndim - 1, -1, -1))))
+
+
+def vector_to_ants_order(array: np.ndarray) -> np.ndarray:
+    """``(D, *torch_reversed_spatial)`` -> ``(*ants_direct_spatial, D)``:
+    reverse only the spatial axes (leave axis 0, the vector component axis,
+    in place) then move it to the end, matching
+    ``ants.from_numpy(..., has_components=True)``'s array order.
+    """
+    spatial_axes_reversed = (0,) + tuple(range(array.ndim - 1, 0, -1))
+    reordered = np.transpose(array, spatial_axes_reversed)
+    return np.ascontiguousarray(np.moveaxis(reordered, 0, -1))
+
+
+def synchronize(device: torch.device) -> None:
+    """Wait for asynchronous accelerator work before timing boundaries."""
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    elif device.type == "mps":
+        torch.mps.synchronize()
+
+
+def report(label: str, ants_array: np.ndarray, torch_array: np.ndarray) -> None:
+    """Print RMSE/MAE/correlation between an ANTsPy array (direct order)
+    and this package's dense output (already reordered to match).
+    """
+    difference = torch_array - ants_array
+    rmse = np.sqrt(np.mean(difference**2))
+    mae = np.mean(np.abs(difference))
+    correlation = np.corrcoef(ants_array.ravel(), torch_array.ravel())[0, 1]
+    print(f"  {label}: RMSE={rmse:.6g}  MAE={mae:.6g}  correlation={correlation:.8f}")
+
+
+def load_image_or_none(name: str):
+    if name is None:
+        return None
+    path = Path(name)
+    if not path.exists() and name in ("r16", "r27", "r62", "r64", "r85"):
+        name = ants.get_ants_data(name)
+    return ants.image_read(str(name)).clone("double")
+
+
+def grid_parametric_points(size):
+    """Every index of a ``size``-shaped (ITK order) grid, as ``(P, dim)``
+    points -- ``indexing="ij"`` keeps flatten order consistent with a
+    ``size``-shaped NumPy array's own ``.ravel()`` order, so ``arr.reshape(-1,
+    1)`` and this function's output describe the same points in the same
+    order.
+    """
+    axes = [np.arange(s) for s in size]
+    mesh = np.meshgrid(*axes, indexing="ij")
+    return np.column_stack([m.ravel() for m in mesh]).astype(np.float64)
+
+
+def compare_object_to_scattered_data(args, rng: np.random.Generator, device: torch.device) -> None:
+    print("\n=== fit_bspline_object_to_scattered_data (scalar) ===")
+    image = load_image_or_none(args.image)
+    if image is not None:
+        size = tuple(int(v) for v in image.shape)
+        values = image.numpy().astype(np.float64)
+        origin = tuple(float(v) for v in image.origin)
+        spacing = tuple(float(v) for v in image.spacing)
+    else:
+        size = tuple(args.size[: args.dimension]) if args.size else (48, 40, 32)[: args.dimension]
+        axes = [np.linspace(-1, 1, s) for s in size]
+        mesh = np.meshgrid(*axes, indexing="ij")
+        values = np.sin(2.0 * mesh[0]) * np.cos(2.0 * mesh[1])
+        if args.dimension == 3:
+            values = values * np.cos(1.5 * mesh[2])
+        origin = (0.0,) * args.dimension
+        spacing = (1.0,) * args.dimension
+    dimension = len(size)
+
+    parametric_full = grid_parametric_points(size)
+    scattered_full = values.reshape(-1, 1)
+    if args.num_points and args.num_points < scattered_full.shape[0]:
+        # Genuinely scattered (off-grid) points: sample continuous
+        # parametric locations, not just a subset of the grid indices.
+        points = rng.uniform(0.0, np.array(size, dtype=np.float64) - 1.0, size=(args.num_points, dimension))
+        # Nearest-neighbor lookup into the dense grid gives a well-defined
+        # scalar value at each off-grid parametric location without
+        # requiring interpolation machinery in this comparison script.
+        indices = np.rint(points).astype(np.int64)
+        for d in range(dimension):
+            indices[:, d] = np.clip(indices[:, d], 0, size[d] - 1)
+        flat_indices = np.ravel_multi_index(indices.T, size)
+        scattered_data = scattered_full[flat_indices]
+        parametric_data = points
+    else:
+        scattered_data = scattered_full
+        parametric_data = parametric_full
+
+    weights = rng.uniform(0.5, 1.5, size=scattered_data.shape[0]) if args.random_weights else None
+
+    kwargs = dict(
+        parametric_domain_origin=list(origin),
+        parametric_domain_spacing=list(spacing),
+        parametric_domain_size=list(size),
+        number_of_fitting_levels=args.number_of_fitting_levels,
+        mesh_size=args.mesh_size[:dimension] if args.mesh_size else 4,
+    )
+
+    start = time.perf_counter()
+    ants_result = ants.fit_bspline_object_to_scattered_data(scattered_data, parametric_data, data_weights=weights, **kwargs)
+    ants_seconds = time.perf_counter() - start
+    ants_array = ants_result.numpy().astype(np.float64)
+
+    torch_device = torch.device(args.device)
+    synchronize(torch_device)
+    start = time.perf_counter()
+    torch_dense = antstorch.fit_bspline_object_to_scattered_data(
+        scattered_data, parametric_data, data_weights=weights, device=torch_device, dtype=torch.float64, **kwargs
+    )
+    synchronize(torch_device)
+    torch_seconds = time.perf_counter() - start
+    torch_array = reverse_axes(torch_dense[0, 0].detach().cpu().numpy())
+
+    print(f"  points={scattered_data.shape[0]}, size={size}, mesh_size={kwargs['mesh_size']}, levels={kwargs['number_of_fitting_levels']}")
+    print(f"  ANTs runtime:      {ants_seconds:.3f} s")
+    print(f"  ANTsTorch runtime: {torch_seconds:.3f} s on {torch_device}")
+    report("scattered fit", ants_array, torch_array)
+
+    if args.output_prefix:
+        prefix = Path(args.output_prefix)
+        ants.image_write(ants_result, f"{prefix}_ants_scattered_fit.nii.gz")
+        ants.image_write(ants.from_numpy(torch_array, origin=origin, spacing=spacing), f"{prefix}_antstorch_scattered_fit.nii.gz")
+
+
+def compare_displacement_field_from_points(args, rng: np.random.Generator, device: torch.device) -> None:
+    print("\n=== fit_bspline_displacement_field (scattered points) ===")
+    dimension = args.dimension
+    size = tuple(args.size[:dimension]) if args.size else (60, 45, 32)[:dimension]
+    point_count = args.num_points or 200
+    margin = 5.0
+    lower = np.full(dimension, margin)
+    upper = np.array(size, dtype=np.float64) - 1.0 - margin
+    points = rng.uniform(lower, upper, size=(point_count, dimension))
+    deltas = rng.normal(scale=3.0, size=(point_count, dimension))
+    weights = rng.uniform(0.5, 1.5, size=point_count) if args.random_weights else None
+
+    if args.enforce_stationary_boundary:
+        print(
+            "  NOTE: --enforce-stationary-boundary is on. ANTsTorch applies it as a "
+            "post-hoc edge mask, while ITK adds high-weight zero observations during "
+            "the fit -- a documented simplification (see fit_bspline_displacement_field's "
+            "docstring). Expect a larger disagreement than with it off; pass "
+            "--no-enforce-stationary-boundary to validate the fit itself."
+        )
+
+    kwargs = dict(
+        number_of_fitting_levels=args.number_of_fitting_levels,
+        mesh_size=args.mesh_size[:dimension] if args.mesh_size else 1,
+        enforce_stationary_boundary=args.enforce_stationary_boundary,
+    )
+
+    start = time.perf_counter()
+    ants_result = ants.fit_bspline_displacement_field(
+        displacement_origins=points,
+        displacements=deltas,
+        displacement_weights=weights,
+        origin=[0.0] * dimension,
+        spacing=[1.0] * dimension,
+        size=list(size),
+        direction=np.eye(dimension),
+        **kwargs,
+    )
+    ants_seconds = time.perf_counter() - start
+    ants_array = ants_result.numpy().astype(np.float64)
+
+    torch_device = torch.device(args.device)
+    domain = antstorch.BSplineDomain(size=size, spacing=(1.0,) * dimension, origin=(0.0,) * dimension)
+    synchronize(torch_device)
+    start = time.perf_counter()
+    torch_dense = antstorch.fit_bspline_displacement_field(
+        displacement_origins=torch.as_tensor(points, device=torch_device),
+        displacements=torch.as_tensor(deltas, device=torch_device),
+        displacement_weights=None if weights is None else torch.as_tensor(weights, device=torch_device),
+        domain=domain,
+        **kwargs,
+    )
+    synchronize(torch_device)
+    torch_seconds = time.perf_counter() - start
+    torch_array = vector_to_ants_order(torch_dense[0].detach().cpu().numpy())
+
+    print(f"  points={point_count}, size={size}, mesh_size={kwargs['mesh_size']}, levels={kwargs['number_of_fitting_levels']}")
+    print(f"  ANTs runtime:      {ants_seconds:.3f} s")
+    print(f"  ANTsTorch runtime: {torch_seconds:.3f} s on {torch_device}")
+    for component in range(dimension):
+        report(f"component {component}", ants_array[..., component], torch_array[..., component])
+
+    if args.output_prefix:
+        prefix = Path(args.output_prefix)
+        ants.image_write(ants_result, f"{prefix}_ants_displacement_points.nii.gz")
+        ants.image_write(
+            ants.from_numpy(torch_array, origin=[0.0] * dimension, spacing=[1.0] * dimension, has_components=True),
+            f"{prefix}_antstorch_displacement_points.nii.gz",
+        )
+
+
+def compare_displacement_field_from_dense_field(args, rng: np.random.Generator, device: torch.device) -> None:
+    print("\n=== fit_bspline_displacement_field (dense field) ===")
+    dimension = args.dimension
+    size = tuple(args.size[:dimension]) if args.size else (40, 32, 24)[:dimension]
+    # ants.from_numpy(..., has_components=True) expects the array shaped
+    # directly in ITK order (size_x, size_y[, size_z], components).
+    field = rng.normal(scale=0.1, size=size + (dimension,))
+
+    kwargs = dict(
+        number_of_fitting_levels=args.number_of_fitting_levels,
+        mesh_size=args.mesh_size[:dimension] if args.mesh_size else 1,
+        enforce_stationary_boundary=args.enforce_stationary_boundary,
+    )
+
+    try:
+        ants_field_image = ants.from_numpy(field, spacing=(1.0,) * dimension, has_components=True)
+        start = time.perf_counter()
+        ants_result = ants.fit_bspline_displacement_field(
+            displacement_field=ants_field_image,
+            origin=[0.0] * dimension,
+            spacing=[1.0] * dimension,
+            size=list(size),
+            direction=np.eye(dimension),
+            **kwargs,
+        )
+        ants_seconds = time.perf_counter() - start
+    except (RuntimeError, AttributeError) as error:
+        print(f"  SKIPPED: this ANTsPy build could not run the dense-field path ({error}).")
+        return
+    ants_array = ants_result.numpy().astype(np.float64)
+
+    torch_device = torch.device(args.device)
+    # ANTsPy stores vector fields as ``(*size, D)`` in direct ITK order,
+    # whereas ANTsTorch uses ``(N, D, *reversed(size))``.
+    component_first_reversed = np.transpose(
+        field, (field.ndim - 1,) + tuple(range(field.ndim - 2, -1, -1))
+    )
+    field_torch = torch.as_tensor(
+        np.ascontiguousarray(component_first_reversed), device=torch_device
+    ).unsqueeze(0)
+    domain = antstorch.BSplineDomain(size=size, spacing=(1.0,) * dimension, origin=(0.0,) * dimension)
+    synchronize(torch_device)
+    start = time.perf_counter()
+    torch_dense = antstorch.fit_bspline_displacement_field(displacement_field=field_torch, domain=domain, **kwargs)
+    synchronize(torch_device)
+    torch_seconds = time.perf_counter() - start
+    torch_array = vector_to_ants_order(torch_dense[0].detach().cpu().numpy())
+
+    print(f"  size={size}, mesh_size={kwargs['mesh_size']}, levels={kwargs['number_of_fitting_levels']}")
+    print(f"  ANTs runtime:      {ants_seconds:.3f} s")
+    print(f"  ANTsTorch runtime: {torch_seconds:.3f} s on {torch_device}")
+    for component in range(dimension):
+        report(f"component {component}", ants_array[..., component], torch_array[..., component])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--image", default=None, help="Image path, or a bundled ANTsPy test image name (e.g. r16). Omit for synthetic data.")
+    parser.add_argument("--dimension", type=int, default=2, choices=(2, 3), help="Dimension for synthetic data (ignored when --image is given).")
+    parser.add_argument("--size", type=int, nargs="+", default=None, help="Domain size for synthetic data, ITK order.")
+    parser.add_argument("--num-points", type=int, default=None, help="Random/off-grid point count (comparison 1) or scattered point count (comparison 2). Default: full grid for comparison 1, 200 for comparison 2.")
+    parser.add_argument("--mesh-size", type=int, nargs="+", default=None, help="B-spline mesh size, ITK order (default: 4 for comparison 1, 1 for comparisons 2-3).")
+    parser.add_argument("--number-of-fitting-levels", type=int, default=4)
+    parser.add_argument("--random-weights", action="store_true", help="Use random per-point weights instead of uniform.")
+    parser.add_argument("--device", default="cpu", help="PyTorch device, e.g. cpu or cuda")
+    parser.add_argument("--enforce-stationary-boundary", dest="enforce_stationary_boundary", action="store_true", default=False)
+    parser.add_argument("--no-enforce-stationary-boundary", dest="enforce_stationary_boundary", action="store_false")
+    parser.add_argument("--skip-object-to-scattered-data", action="store_true")
+    parser.add_argument("--skip-displacement-points", action="store_true")
+    parser.add_argument("--skip-displacement-dense-field", action="store_true")
+    parser.add_argument("--output-prefix", default="bspline_scattered_comparison", help="Prefix for written .nii.gz outputs, or '' to skip writing files.")
+    parser.add_argument("--seed", type=int, default=1729)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("--device cuda was requested, but CUDA is not available")
+    if device.type == "mps" and not torch.backends.mps.is_available():
+        raise RuntimeError("--device mps was requested, but MPS is not available")
+    rng = np.random.default_rng(args.seed)
+
+    if not args.skip_object_to_scattered_data:
+        compare_object_to_scattered_data(args, rng, device)
+    if not args.skip_displacement_points:
+        compare_displacement_field_from_points(args, rng, device)
+    if not args.skip_displacement_dense_field:
+        compare_displacement_field_from_dense_field(args, rng, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compare_n4_bias_field_correction.py
+++ b/tools/compare_n4_bias_field_correction.py
@@ -176,6 +176,10 @@ def main() -> None:
     print(f"Geometry: size={t1.shape}, spacing={t1.spacing}, origin={t1.origin}")
     print(f"ANTs runtime:      {ants_seconds:.3f} s (correction + bias-field run)")
     print(f"ANTsTorch runtime: {torch_seconds:.3f} s on {device} (correction + bias-field run)")
+    print(f"ANTs intensity range: {corrected_ants_array.min():.6g} to {corrected_ants_array.max():.6g}")
+    print(f"ANTsTorch intensity range: {corrected_torch_array.min():.6g} to {corrected_torch_array.max():.6g}") 
+    print(f"ANTs bias-field range: {normalized_ants_bias.min():.6g} to {normalized_ants_bias.max():.6g}")
+    print(f"ANTsTorch bias-field range: {normalized_torch_bias.min():.6g} to {normalized_torch_bias.max():.6g}")
     print(f"B-spline accumulation: {'stable matrix reduction' if device.type == 'mps' else 'vectorized scatter'}")
     print(f"Corrected-image RMSE: {np.sqrt(np.mean(corrected_difference**2)):.6g}")
     print(


### PR DESCRIPTION
Okay @stnava , I think this is as close as we're going to get to being identical.  

```bash
% python3 tools/compare_n4_bias_field_correction.py
Input: /Users/ntustison/.antspy/r16slice.jpg
Geometry: size=(256, 256), spacing=(1.0, 1.0), origin=(0.0, 0.0)
ANTs runtime:      0.263 s (correction + bias-field run)
ANTsTorch runtime: 0.342 s on cpu (correction + bias-field run)
ANTs intensity range: 0 to 625.948
ANTsTorch intensity range: 0 to 623.862
ANTs bias-field range: 0.420166 to 1.31448
ANTsTorch bias-field range: 0.420168 to 1.31449
B-spline accumulation: vectorized scatter
Corrected-image RMSE: 0.813706
Scale-aligned corrected-image RMSE: 0.0137278 (scale=1.0036124)
Normalized log-bias MAE: 2.43777e-05
Normalized log-bias correlation: 0.99999999
Outputs written with prefix: n4_comparison
```

I also add the PyTorch b-spline fitting 

```
 % python3 tools/compare_bspline_scattered_data.py 

=== fit_bspline_object_to_scattered_data (scalar) ===
  points=1920, size=(48, 40), mesh_size=4, levels=4
  ANTs runtime:      0.007 s
  ANTsTorch runtime: 0.030 s on cpu
  scattered fit: RMSE=3.45865e-06  MAE=1.88229e-06  correlation=1.00000000

=== fit_bspline_displacement_field (scattered points) ===
  points=200, size=(60, 45), mesh_size=1, levels=4
  ANTs runtime:      0.004 s
  ANTsTorch runtime: 0.004 s on cpu
  component 0: RMSE=8.19859e-05  MAE=2.03351e-05  correlation=0.99999999
  component 1: RMSE=7.87166e-05  MAE=1.86265e-05  correlation=1.00000000

=== fit_bspline_displacement_field (dense field) ===
  size=(40, 32), mesh_size=1, levels=4
  ANTs runtime:      0.003 s
  ANTsTorch runtime: 0.008 s on cpu
  component 0: RMSE=1.32881e-06  MAE=3.97472e-07  correlation=1.00000000
  component 1: RMSE=6.68805e-07  MAE=2.16706e-07  correlation=1.00000000
```