### PR TITLE
WIP:  B-spline SVF image registration.

### DIFF
--- a/antstorch/bspline_flows/__init__.py
+++ b/antstorch/bspline_flows/__init__.py
@@ -11,8 +11,15 @@ from .bspline_synthesis import (
 )
 from .deterministic_registration import DeterministicBSplineRegistration
 from .n4_bias_field_correction import N4BiasFieldCorrection, n4_bias_field_correction
+from .registration import registration
 from .scaling_and_squaring import ScalingAndSquaring, scaling_and_squaring
-from .similarity import bending_energy, mean_squared_error, normalized_cross_correlation_loss, squared_l2_energy
+from .similarity import (
+    ants_neighborhood_correlation_loss,
+    bending_energy,
+    mean_squared_error,
+    normalized_cross_correlation_loss,
+    squared_l2_energy,
+)
 from .spatial_transform import (
     ALIGN_CORNERS,
     compose_displacements,
@@ -35,9 +42,11 @@ __all__ = [
     "DeterministicBSplineRegistration",
     "N4BiasFieldCorrection",
     "n4_bias_field_correction",
+    "registration",
     "ScalingAndSquaring",
     "scaling_and_squaring",
     "bending_energy",
+    "ants_neighborhood_correlation_loss",
     "mean_squared_error",
     "normalized_cross_correlation_loss",
     "squared_l2_energy",

--- a/antstorch/bspline_flows/deterministic_registration.py
+++ b/antstorch/bspline_flows/deterministic_registration.py
@@ -7,7 +7,13 @@ from torch import Tensor, nn
 from .bspline_domain import BSplineDomain
 from .bspline_synthesis import CubicBSplineSynthesis
 from .scaling_and_squaring import ScalingAndSquaring
-from .similarity import bending_energy, mean_squared_error, normalized_cross_correlation_loss, squared_l2_energy
+from .similarity import (
+    ants_neighborhood_correlation_loss,
+    bending_energy,
+    mean_squared_error,
+    normalized_cross_correlation_loss,
+    squared_l2_energy,
+)
 from .spatial_transform import jacobian_determinant, warp_image
 
 
@@ -21,6 +27,7 @@ class DeterministicBSplineRegistration(nn.Module):
         *,
         squaring_steps: int = 7,
         similarity: str = "mse",
+        neighborhood_radius=2,
         padding_mode: str = "zeros",
         coefficient_weight: float = 0.0,
         velocity_weight: float = 0.0,
@@ -39,9 +46,10 @@ class DeterministicBSplineRegistration(nn.Module):
             chunk_size=synthesis_chunk_size,
         )
         self.exponential = ScalingAndSquaring(fixed_domain, squaring_steps)
-        if similarity not in ("mse", "ncc"):
-            raise ValueError("similarity must be 'mse' or 'ncc'")
+        if similarity not in ("mse", "ncc", "ants_ncc"):
+            raise ValueError("similarity must be 'mse', 'ncc', or 'ants_ncc'")
         self.similarity = similarity
+        self.neighborhood_radius = neighborhood_radius
         self.padding_mode = padding_mode
         self.coefficient_weight = float(coefficient_weight)
         self.velocity_weight = float(velocity_weight)
@@ -61,11 +69,14 @@ class DeterministicBSplineRegistration(nn.Module):
 
     def forward(self, coefficients: Tensor, moving: Tensor, fixed: Tensor) -> Dict[str, Tensor]:
         result = self.transform(coefficients, moving)
-        similarity = (
-            mean_squared_error(fixed, result["warped_moving"])
-            if self.similarity == "mse"
-            else normalized_cross_correlation_loss(fixed, result["warped_moving"])
-        )
+        if self.similarity == "mse":
+            similarity = mean_squared_error(fixed, result["warped_moving"])
+        elif self.similarity == "ncc":
+            similarity = normalized_cross_correlation_loss(fixed, result["warped_moving"])
+        else:
+            similarity = ants_neighborhood_correlation_loss(
+                fixed, result["warped_moving"], self.neighborhood_radius
+            )
         coefficient_regularization = squared_l2_energy(coefficients)
         velocity_regularization = squared_l2_energy(result["velocity"])
         bending_regularization = bending_energy(result["velocity"], self.fixed_domain)
@@ -86,4 +97,3 @@ class DeterministicBSplineRegistration(nn.Module):
             }
         )
         return result
-

--- a/antstorch/bspline_flows/registration.py
+++ b/antstorch/bspline_flows/registration.py
@@ -1,0 +1,388 @@
+"""High-level optimization interface for B-spline SVF registration."""
+
+from math import isfinite
+from typing import Dict, Optional, Sequence, Union
+
+import torch
+from torch import Tensor
+from torch.nn import functional as F
+
+from .bspline_domain import BSplineDomain
+from .bspline_synthesis import refine_bspline_coefficients
+from .deterministic_registration import DeterministicBSplineRegistration
+
+
+def _axis_values(value, dimension: int, name: str, *, minimum: int) -> tuple:
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer or a sequence of integers")
+    if isinstance(value, int):
+        values = (value,) * dimension
+    else:
+        try:
+            values = tuple(value)
+        except TypeError as error:
+            raise TypeError(f"{name} must be an integer or a sequence of integers") from error
+        if len(values) != dimension:
+            raise ValueError(f"{name} must have {dimension} values")
+    if any(isinstance(v, bool) or not isinstance(v, int) for v in values):
+        raise TypeError(f"{name} values must be integers")
+    if any(v < minimum for v in values):
+        raise ValueError(f"{name} values must be at least {minimum}")
+    return values
+
+
+def _closed_axes(closed, dimension: int) -> tuple:
+    if isinstance(closed, bool):
+        return (closed,) * dimension
+    values = tuple(bool(value) for value in closed)
+    if len(values) != dimension:
+        raise ValueError(f"closed must have {dimension} values")
+    return values
+
+
+def _validate_images(
+    fixed: Tensor,
+    moving: Tensor,
+    fixed_domain: BSplineDomain,
+    moving_domain: BSplineDomain,
+) -> None:
+    if not isinstance(fixed, Tensor) or not isinstance(moving, Tensor):
+        raise TypeError("fixed and moving must be torch tensors")
+    if fixed.ndim != fixed_domain.dimension + 2 or tuple(fixed.shape[2:]) != fixed_domain.torch_size:
+        raise ValueError("fixed tensor shape does not match fixed_domain")
+    if moving.ndim != moving_domain.dimension + 2 or tuple(moving.shape[2:]) != moving_domain.torch_size:
+        raise ValueError("moving tensor shape does not match moving_domain")
+    if fixed.shape[:2] != moving.shape[:2]:
+        raise ValueError("fixed and moving must have identical batch and channel sizes")
+    if not fixed.is_floating_point() or not moving.is_floating_point():
+        raise TypeError("fixed and moving must have floating-point dtypes")
+    if fixed.dtype != moving.dtype or fixed.device != moving.device:
+        raise ValueError("fixed and moving must have the same dtype and device")
+
+
+def _level_values(value, levels: int, name: str, cast, minimum) -> tuple:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        values = (cast(value),) * levels
+    else:
+        try:
+            values = tuple(cast(item) for item in value)
+        except (TypeError, ValueError) as error:
+            raise TypeError(f"{name} must be a scalar or a sequence") from error
+        if len(values) != levels:
+            raise ValueError(f"{name} must have one value per resolution level")
+    if any(not isfinite(item) or item < minimum for item in values):
+        raise ValueError(f"{name} values must be finite and at least {minimum}")
+    return values
+
+
+def _pyramid_configuration(shrink_factors, smoothing_sigmas, iterations, learning_rate):
+    try:
+        factors = tuple(shrink_factors)
+    except TypeError as error:
+        raise TypeError("shrink_factors must be a sequence of positive integers") from error
+    if not factors or any(isinstance(v, bool) or not isinstance(v, int) or v < 1 for v in factors):
+        raise ValueError("shrink_factors must contain positive integers")
+    if factors[-1] != 1 or any(coarse != 2 * fine for coarse, fine in zip(factors, factors[1:])):
+        raise ValueError("shrink_factors must be a dyadic coarse-to-fine sequence ending in 1")
+    levels = len(factors)
+    sigmas = _level_values(
+        tuple(0.0 for _ in factors) if smoothing_sigmas is None else smoothing_sigmas,
+        levels,
+        "smoothing_sigmas",
+        float,
+        0.0,
+    )
+    iteration_inputs = (iterations,) * levels if isinstance(iterations, int) else tuple(iterations)
+    if len(iteration_inputs) != levels:
+        raise ValueError("iterations must have one value per resolution level")
+    if any(isinstance(v, bool) or not isinstance(v, int) or v < 0 for v in iteration_inputs):
+        raise ValueError("iterations values must be non-negative integers")
+    level_iterations = iteration_inputs
+    level_rates = _level_values(learning_rate, levels, "learning_rate", float, 0.0)
+    if any(rate == 0 for rate in level_rates):
+        raise ValueError("learning_rate values must be positive")
+    return factors, sigmas, level_iterations, level_rates
+
+
+def _smooth_image(image: Tensor, domain: BSplineDomain, sigma: float) -> Tensor:
+    """Gaussian smoothing with ``sigma`` in physical domain units."""
+    if sigma == 0:
+        return image
+    sigma_torch = tuple(reversed(tuple(sigma / spacing for spacing in domain.spacing)))
+    axes = []
+    radii = []
+    for axis_sigma in sigma_torch:
+        radius = max(1, int(3.0 * axis_sigma + 0.5))
+        radii.append(radius)
+        coordinate = torch.arange(-radius, radius + 1, dtype=image.dtype, device=image.device)
+        axis_kernel = torch.exp(-0.5 * (coordinate / axis_sigma).square())
+        axes.append(axis_kernel / axis_kernel.sum())
+    kernel = axes[0]
+    for axis_kernel in axes[1:]:
+        kernel = kernel.unsqueeze(-1) * axis_kernel.reshape((1,) * kernel.ndim + (-1,))
+    kernel = kernel.reshape((1, 1) + kernel.shape).expand((image.shape[1], 1) + kernel.shape)
+    padding = tuple(value for radius in reversed(radii) for value in (radius, radius))
+    padded = F.pad(image, padding, mode="replicate")
+    convolution = F.conv2d if domain.dimension == 2 else F.conv3d
+    return convolution(padded, kernel, groups=image.shape[1])
+
+
+def _downsample(image: Tensor, domain: BSplineDomain, factor: int):
+    if factor == 1:
+        return image, domain
+    size_itk = tuple(max(2, (size - 1) // factor + 1) for size in domain.size)
+    spacing = tuple(extent / (size - 1) for extent, size in zip(domain.physical_extent, size_itk))
+    reduced_domain = BSplineDomain(size_itk, spacing, domain.origin, domain.direction)
+    mode = "bilinear" if domain.dimension == 2 else "trilinear"
+    reduced = F.interpolate(image, size=reduced_domain.torch_size, mode=mode, align_corners=True)
+    return reduced, reduced_domain
+
+
+def registration(
+    fixed: Tensor,
+    moving: Tensor,
+    fixed_domain: BSplineDomain,
+    moving_domain: Optional[BSplineDomain] = None,
+    *,
+    mesh_size: Union[int, Sequence[int]] = 1,
+    coefficient_grid_size: Optional[Union[int, Sequence[int]]] = None,
+    iterations: Union[int, Sequence[int]] = 100,
+    learning_rate: Union[float, Sequence[float]] = 1e-2,
+    optimizer: str = "adam",
+    similarity: str = "mse",
+    neighborhood_radius: Union[int, Sequence[int]] = 2,
+    coefficient_weight: float = 0.0,
+    velocity_weight: float = 0.0,
+    bending_weight: float = 0.0,
+    squaring_steps: int = 7,
+    padding_mode: str = "zeros",
+    closed=False,
+    stationary_boundary: bool = True,
+    convergence_tolerance: Optional[float] = None,
+    return_loss_history: bool = True,
+    initial_coefficients: Optional[Tensor] = None,
+    shrink_factors: Sequence[int] = (1,),
+    smoothing_sigmas: Optional[Union[float, Sequence[float]]] = None,
+    verbose: bool = False,
+    detach_outputs: bool = True,
+    synthesis_chunk_size: Optional[int] = 262144,
+) -> Dict[str, object]:
+    """Optimize a cubic B-spline stationary-velocity transformation.
+
+    Images have shape ``(N, C, Y, X)`` or ``(N, C, Z, Y, X)``. Domain,
+    mesh, and coefficient-grid tuples use physical ITK axis order
+    ``(x, y[, z])``; tensor spatial axes are reversed. Velocity and
+    displacement channels are physical x, y, (z) components and their values
+    are in the physical units of the domains. Batches of any positive size are
+    supported, with one coefficient lattice optimized per batch item.
+
+    ``similarity="ants_ncc"`` selects the squared local neighborhood
+    correlation used by ITK/ANTs. ``neighborhood_radius`` is an integer or an
+    ITK-order ``(x, y[, z])`` tuple; its default of 2 matches ITK.
+
+    ``mesh_size`` is the number of B-spline spans. For open axes the
+    coefficient-grid size is ``mesh_size + 3``; for closed axes it equals the
+    mesh size. ``coefficient_grid_size`` can instead specify the control-point
+    count directly. Supplying ``initial_coefficients`` makes its spatial shape
+    authoritative and cannot be combined with ``coefficient_grid_size``.
+
+    ``shrink_factors`` defines a dyadic coarse-to-fine pyramid ending in 1,
+    for example ``(4, 2, 1)``. ``smoothing_sigmas`` are Gaussian sigmas in
+    physical units. ``iterations`` and ``learning_rate`` may be scalars or
+    contain one value per level. Reduced images retain their physical extent,
+    and the open B-spline lattice is refined exactly between levels.
+    Multi-resolution registration of closed axes is not yet supported.
+
+    Set ``verbose=True`` to report each pyramid level and optimization loss.
+
+    By default result tensors are detached, and iteration losses are stored as
+    Python floats so optimization graphs are not retained. Set
+    ``detach_outputs=False`` to retain the graph for the final evaluation only.
+    The inverse displacement is independently computed as ``exp(-velocity)``.
+    """
+    if not isinstance(fixed_domain, BSplineDomain):
+        raise TypeError("fixed_domain must be a BSplineDomain")
+    moving_domain = fixed_domain if moving_domain is None else moving_domain
+    if not isinstance(moving_domain, BSplineDomain):
+        raise TypeError("moving_domain must be a BSplineDomain")
+    if fixed_domain.dimension != moving_domain.dimension:
+        raise ValueError("fixed_domain and moving_domain must have the same dimension")
+    _validate_images(fixed, moving, fixed_domain, moving_domain)
+    if not isinstance(verbose, bool):
+        raise TypeError("verbose must be a bool")
+
+    factors, sigmas, level_iterations, level_rates = _pyramid_configuration(
+        shrink_factors, smoothing_sigmas, iterations, learning_rate
+    )
+    if optimizer not in ("adam", "lbfgs"):
+        raise ValueError("optimizer must be 'adam' or 'lbfgs'")
+    if similarity not in ("mse", "ncc", "ants_ncc"):
+        raise ValueError("similarity must be 'mse', 'ncc', or 'ants_ncc'")
+    if padding_mode not in ("zeros", "border", "reflection"):
+        raise ValueError("padding_mode must be 'zeros', 'border', or 'reflection'")
+    for name, weight in (("coefficient_weight", coefficient_weight), ("velocity_weight", velocity_weight), ("bending_weight", bending_weight)):
+        if not isinstance(weight, (int, float)) or not isfinite(weight) or weight < 0:
+            raise ValueError(f"{name} must be finite and non-negative")
+    if convergence_tolerance is not None and (
+        not isinstance(convergence_tolerance, (int, float))
+        or not isfinite(convergence_tolerance)
+        or convergence_tolerance < 0
+    ):
+        raise ValueError("convergence_tolerance must be finite and non-negative or None")
+
+    dimension = fixed_domain.dimension
+    closed_axes = _closed_axes(closed, dimension)
+    if len(factors) > 1 and any(closed_axes):
+        raise ValueError("multi-resolution registration does not yet support closed axes")
+    if initial_coefficients is not None:
+        if coefficient_grid_size is not None:
+            raise ValueError("coefficient_grid_size cannot be used with initial_coefficients")
+        expected_prefix = (fixed.shape[0], dimension)
+        if initial_coefficients.ndim != dimension + 2 or initial_coefficients.shape[:2] != expected_prefix:
+            raise ValueError("initial_coefficients has an incompatible batch, vector, or spatial rank")
+        if any(size < 4 for size in initial_coefficients.shape[2:]):
+            raise ValueError("initial_coefficients requires at least four control points per axis")
+        if not initial_coefficients.is_floating_point():
+            raise TypeError("initial_coefficients must have a floating-point dtype")
+        if initial_coefficients.dtype != fixed.dtype or initial_coefficients.device != fixed.device:
+            raise ValueError("initial_coefficients must match the fixed image dtype and device")
+        coefficients = initial_coefficients.detach().clone().requires_grad_(True)
+    else:
+        if coefficient_grid_size is None:
+            mesh = _axis_values(mesh_size, dimension, "mesh_size", minimum=1)
+            lattice_itk = tuple(m if periodic else m + 3 for m, periodic in zip(mesh, closed_axes))
+            if any(periodic and size < 4 for periodic, size in zip(closed_axes, lattice_itk)):
+                raise ValueError("closed axes require mesh_size of at least 4")
+        else:
+            lattice_itk = _axis_values(coefficient_grid_size, dimension, "coefficient_grid_size", minimum=4)
+        coefficients = torch.zeros(
+            (fixed.shape[0], dimension) + tuple(reversed(lattice_itk)),
+            dtype=fixed.dtype,
+            device=fixed.device,
+            requires_grad=True,
+        )
+
+    if verbose:
+        print("ANTsTorch B-spline SVF registration configuration:")
+        configuration = (
+            ("fixed_domain", fixed_domain),
+            ("moving_domain", moving_domain),
+            ("fixed_shape", tuple(fixed.shape)),
+            ("moving_shape", tuple(moving.shape)),
+            ("dtype", fixed.dtype),
+            ("device", fixed.device),
+            ("initial_coefficient_shape", tuple(coefficients.shape)),
+            ("mesh_size", mesh_size),
+            ("coefficient_grid_size", coefficient_grid_size),
+            ("initial_coefficients_provided", initial_coefficients is not None),
+            ("shrink_factors", factors),
+            ("smoothing_sigmas", sigmas),
+            ("iterations", level_iterations),
+            ("learning_rate", level_rates),
+            ("optimizer", optimizer),
+            ("similarity", similarity),
+            ("neighborhood_radius", neighborhood_radius),
+            ("coefficient_weight", coefficient_weight),
+            ("velocity_weight", velocity_weight),
+            ("bending_weight", bending_weight),
+            ("squaring_steps", squaring_steps),
+            ("padding_mode", padding_mode),
+            ("closed", closed),
+            ("stationary_boundary", stationary_boundary),
+            ("convergence_tolerance", convergence_tolerance),
+            ("return_loss_history", return_loss_history),
+            ("detach_outputs", detach_outputs),
+            ("synthesis_chunk_size", synthesis_chunk_size),
+        )
+        for name, value in configuration:
+            print(f"  {name}: {value}")
+
+    history = []
+    level_history = []
+    for level, (factor, sigma, iteration_count, rate) in enumerate(
+        zip(factors, sigmas, level_iterations, level_rates)
+    ):
+        if level:
+            coefficients = refine_bspline_coefficients(coefficients.detach()).requires_grad_(True)
+        fixed_level, fixed_level_domain = _downsample(
+            _smooth_image(fixed, fixed_domain, sigma), fixed_domain, factor
+        )
+        moving_level, moving_level_domain = _downsample(
+            _smooth_image(moving, moving_domain, sigma), moving_domain, factor
+        )
+        if verbose:
+            print(
+                f"Resolution level {level + 1}/{len(factors)}: "
+                f"shrink_factor={factor}, smoothing_sigma={sigma:g}, "
+                f"fixed_size={fixed_level_domain.size}, "
+                f"moving_size={moving_level_domain.size}, iterations={iteration_count}"
+            )
+        model = DeterministicBSplineRegistration(
+            fixed_level_domain,
+            moving_level_domain,
+            squaring_steps=squaring_steps,
+            similarity=similarity,
+            neighborhood_radius=neighborhood_radius,
+            padding_mode=padding_mode,
+            coefficient_weight=coefficient_weight,
+            velocity_weight=velocity_weight,
+            bending_weight=bending_weight,
+            closed=closed,
+            stationary_boundary=stationary_boundary,
+            synthesis_chunk_size=synthesis_chunk_size,
+        )
+        optimizer_impl = (
+            torch.optim.Adam([coefficients], lr=rate)
+            if optimizer == "adam"
+            else torch.optim.LBFGS([coefficients], lr=rate, max_iter=20)
+        )
+        current_level_history = []
+        previous = None
+        for _ in range(iteration_count):
+            def closure():
+                optimizer_impl.zero_grad()
+                loss = model(coefficients, moving_level, fixed_level)["loss"]
+                if not torch.isfinite(loss):
+                    raise FloatingPointError(
+                        f"non-finite registration loss at resolution level {level + 1}"
+                    )
+                loss.backward()
+                if coefficients.grad is None or not torch.isfinite(coefficients.grad).all():
+                    raise FloatingPointError(
+                        f"non-finite coefficient gradient at resolution level {level + 1}"
+                    )
+                return loss
+
+            if optimizer == "lbfgs":
+                optimizer_impl.step(closure)
+            else:
+                closure()
+                optimizer_impl.step()
+            with torch.no_grad():
+                current = float(model(coefficients, moving_level, fixed_level)["loss"].item())
+            current_level_history.append(current)
+            if verbose:
+                print(f"  iteration {len(current_level_history):04d}: loss={current:.8g}")
+            if previous is not None and convergence_tolerance is not None:
+                if abs(previous - current) <= convergence_tolerance * max(1.0, abs(previous)):
+                    if verbose:
+                        print(
+                            "  convergence reached: "
+                            f"change={abs(previous - current):.8g}, "
+                            f"tolerance={convergence_tolerance:.8g}"
+                        )
+                    break
+            previous = current
+        level_history.append(current_level_history)
+        history.extend(current_level_history)
+
+    # The final pyramid level is full resolution by construction.
+    result = model(coefficients, moving, fixed)
+    result["forward_displacement"] = result.pop("displacement")
+    result["inverse_displacement"] = model.exponential(-result["velocity"])
+    result["coefficients"] = coefficients
+    result["loss_history"] = history if return_loss_history else None
+    result["level_loss_history"] = level_history if return_loss_history else None
+    if detach_outputs:
+        result = {key: value.detach() if isinstance(value, Tensor) else value for key, value in result.items()}
+    return result

--- a/antstorch/bspline_flows/similarity.py
+++ b/antstorch/bspline_flows/similarity.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch import Tensor
+from torch.nn import functional as F
 
 from .bspline_domain import BSplineDomain
 
@@ -24,6 +25,85 @@ def normalized_cross_correlation_loss(fixed: Tensor, warped_moving: Tensor, eps:
         fixed_centered.square().sum(dim=axes) * moving_centered.square().sum(dim=axes) + eps
     )
     return 1.0 - (numerator / denominator).mean()
+
+
+def ants_neighborhood_correlation_loss(fixed: Tensor, warped_moving: Tensor, radius=2) -> Tensor:
+    """Negative mean squared local correlation used by ITK's ANTs metric.
+
+    ``fixed`` and ``warped_moving`` have shape ``(N, C, Y, X)`` or
+    ``(N, C, Z, Y, X)``. An integer radius is shared by every axis; a tuple
+    uses ITK order ``(x, y[, z])``. Each window has size ``2 * radius + 1``
+    and is truncated at image boundaries. The returned value is the negative
+    mean of the squared, locally mean-centered correlation, matching the sign
+    of ``itk::ANTSNeighborhoodCorrelationImageToImageMetricv4``.
+
+    Unlike ITK's hand-derived dense-transform derivative approximation, this
+    implementation uses PyTorch autograd to differentiate the exact tensor
+    expression through all samples in each neighborhood.
+    """
+    if fixed.shape != warped_moving.shape:
+        raise ValueError("fixed and warped moving images must have identical shapes")
+    dimension = fixed.ndim - 2
+    if dimension not in (2, 3):
+        raise ValueError("ANTS neighborhood correlation supports 2-D or 3-D images")
+    if not fixed.is_floating_point() or not warped_moving.is_floating_point():
+        raise TypeError("fixed and warped moving images must be floating point")
+    if isinstance(radius, bool):
+        raise TypeError("radius must be an integer or a sequence of integers")
+    if isinstance(radius, int):
+        radius_itk = (radius,) * dimension
+    else:
+        radius_itk = tuple(radius)
+        if len(radius_itk) != dimension:
+            raise ValueError(f"radius must have {dimension} values")
+    if any(isinstance(value, bool) or not isinstance(value, int) for value in radius_itk):
+        raise TypeError("radius values must be integers")
+    if any(value < 0 for value in radius_itk):
+        raise ValueError("radius values must be non-negative")
+
+    radius_torch = tuple(reversed(radius_itk))
+    kernel_size = tuple(2 * value + 1 for value in radius_torch)
+    channels = fixed.shape[1]
+    kernel = fixed.new_ones((channels, 1) + kernel_size)
+    convolution = F.conv2d if dimension == 2 else F.conv3d
+
+    def window_sum(value):
+        return convolution(value, kernel, padding=radius_torch, groups=channels)
+
+    count_kernel = fixed.new_ones((1, 1) + kernel_size)
+    count = convolution(
+        fixed.new_ones((fixed.shape[0], 1) + fixed.shape[2:]),
+        count_kernel,
+        padding=radius_torch,
+    )
+    sum_fixed = window_sum(fixed)
+    sum_moving = window_sum(warped_moving)
+    sum_fixed2 = window_sum(fixed.square())
+    sum_moving2 = window_sum(warped_moving.square())
+    sum_fixed_moving = window_sum(fixed * warped_moving)
+    fixed_mean = sum_fixed / count
+    moving_mean = sum_moving / count
+    fixed_variance = sum_fixed2 - 2.0 * fixed_mean * sum_fixed + count * fixed_mean.square()
+    moving_variance = sum_moving2 - 2.0 * moving_mean * sum_moving + count * moving_mean.square()
+    covariance = (
+        sum_fixed_moving
+        - moving_mean * sum_fixed
+        - fixed_mean * sum_moving
+        + count * fixed_mean * moving_mean
+    )
+    denominator = fixed_variance * moving_variance
+    epsilon = torch.finfo(fixed.dtype).eps
+    valid = denominator.abs() > epsilon
+    # ``torch.where`` evaluates both branches. Dividing by the original zero
+    # denominator would therefore create NaNs in autograd even where the ITK
+    # constant-neighborhood fallback of one is selected.
+    safe_denominator = torch.where(valid, denominator, torch.ones_like(denominator))
+    local_correlation = torch.where(
+        valid,
+        covariance.square() / safe_denominator,
+        torch.ones_like(denominator),
+    )
+    return -local_correlation.mean()
 
 
 def squared_l2_energy(value: Tensor) -> Tensor:
@@ -49,4 +129,3 @@ def bending_energy(field: Tensor, domain: BSplineDomain) -> Tensor:
             second = torch.gradient(derivative, spacing=(domain.spacing[j],), dim=(torch_axis,))[0]
             terms.append(second.square().mean() * (2.0 if i != j else 1.0))
     return torch.stack(terms).sum()
-

--- a/tests/bspline_flows/test_registration.py
+++ b/tests/bspline_flows/test_registration.py
@@ -1,0 +1,212 @@
+import pytest
+import torch
+
+from antstorch.bspline_flows import (
+    BSplineDomain,
+    compose_displacements,
+    registration,
+    warp_image,
+)
+
+
+def _blob(domain, dtype=torch.float32):
+    axes = [torch.linspace(-1, 1, size, dtype=dtype) for size in domain.torch_size]
+    coordinates = torch.meshgrid(*axes, indexing="ij")
+    return torch.exp(-8 * sum(axis.square() for axis in coordinates))[None, None]
+
+
+@pytest.mark.parametrize("size", [(9, 8), (7, 6, 5)])
+def test_registration_identity_shapes_and_finite_results(size):
+    domain = BSplineDomain(size)
+    image = _blob(domain)
+    result = registration(image, image, domain, iterations=0, mesh_size=1, squaring_steps=2)
+
+    expected_field = (1, len(size)) + domain.torch_size
+    assert result["warped_moving"].shape == image.shape
+    assert result["velocity"].shape == expected_field
+    assert result["forward_displacement"].shape == expected_field
+    assert result["inverse_displacement"].shape == expected_field
+    assert result["jacobian_determinant"].shape == (1,) + domain.torch_size
+    assert result["loss"].item() == pytest.approx(0.0)
+    assert torch.isfinite(result["jacobian_determinant"]).all()
+    assert not result["loss"].requires_grad
+
+
+def test_registration_reduces_loss_for_synthetic_translation():
+    torch.manual_seed(4)
+    domain = BSplineDomain((16, 14))
+    moving = _blob(domain)
+    displacement = torch.zeros((1, 2) + domain.torch_size)
+    displacement[:, 0] = 0.7
+    fixed = warp_image(moving, displacement, domain, padding_mode="border")
+    initial = registration(fixed, moving, domain, iterations=0, mesh_size=1, padding_mode="border")["loss"]
+    result = registration(
+        fixed,
+        moving,
+        domain,
+        iterations=30,
+        learning_rate=0.08,
+        mesh_size=1,
+        squaring_steps=3,
+        padding_mode="border",
+    )
+    assert result["loss"] < initial
+    assert result["loss_history"][-1] < result["loss_history"][0]
+
+
+@pytest.mark.parametrize("similarity", ["mse", "ncc", "ants_ncc"])
+def test_registration_similarity_modes_and_final_graph(similarity):
+    domain = BSplineDomain((8, 7))
+    moving = _blob(domain).requires_grad_()
+    fixed = torch.roll(moving.detach(), 1, -1)
+    result = registration(
+        fixed,
+        moving,
+        domain,
+        iterations=1,
+        similarity=similarity,
+        detach_outputs=False,
+        return_loss_history=False,
+        squaring_steps=1,
+    )
+    result["loss"].backward()
+    assert moving.grad is not None
+    assert torch.isfinite(moving.grad).all()
+    assert result["coefficients"].grad is not None
+    assert torch.isfinite(result["coefficients"].grad).all()
+    assert result["loss_history"] is None
+
+
+def test_forward_inverse_composition_is_near_identity():
+    domain = BSplineDomain((12, 11))
+    coefficients = torch.randn(1, 2, 5, 5) * 0.02
+    result = registration(
+        _blob(domain),
+        _blob(domain),
+        domain,
+        initial_coefficients=coefficients,
+        iterations=0,
+        squaring_steps=5,
+    )
+    composition = compose_displacements(
+        result["forward_displacement"], result["inverse_displacement"], domain
+    )
+    assert composition.abs().max() < 2e-3
+
+
+def test_distinct_moving_domain_and_batch_are_supported():
+    fixed_domain = BSplineDomain((8, 7), spacing=(1.0, 1.0))
+    moving_domain = BSplineDomain((10, 9), spacing=(0.8, 0.75))
+    fixed = torch.zeros(2, 1, *fixed_domain.torch_size)
+    moving = torch.zeros(2, 1, *moving_domain.torch_size)
+    result = registration(fixed, moving, fixed_domain, moving_domain, iterations=0)
+    assert result["warped_moving"].shape == fixed.shape
+    assert result["coefficients"].shape[:2] == (2, 2)
+
+
+def test_multiresolution_refines_lattice_and_reports_each_level():
+    domain = BSplineDomain((17, 15), spacing=(0.8, 1.2), origin=(2.0, -3.0))
+    image = _blob(domain)
+    result = registration(
+        image,
+        image,
+        domain,
+        mesh_size=1,
+        shrink_factors=(4, 2, 1),
+        smoothing_sigmas=(1.5, 0.75, 0.0),
+        iterations=(0, 0, 0),
+    )
+    # Open cubic lattice refinement: 4 -> 5 -> 7 control points.
+    assert result["coefficients"].shape == (1, 2, 7, 7)
+    assert result["level_loss_history"] == [[], [], []]
+    assert result["warped_moving"].shape == image.shape
+    assert result["loss"].item() == pytest.approx(0.0)
+
+
+def test_multiresolution_optimization_runs_coarse_to_fine():
+    domain = BSplineDomain((17, 15))
+    moving = _blob(domain)
+    fixed = torch.roll(moving, 1, -1)
+    result = registration(
+        fixed,
+        moving,
+        domain,
+        shrink_factors=(2, 1),
+        smoothing_sigmas=(1.0, 0.0),
+        iterations=(2, 2),
+        learning_rate=(0.05, 0.02),
+        squaring_steps=1,
+    )
+    assert len(result["level_loss_history"]) == 2
+    assert [len(level) for level in result["level_loss_history"]] == [2, 2]
+    assert result["loss_history"] == sum(result["level_loss_history"], [])
+    assert torch.isfinite(result["loss"])
+
+
+def test_multiresolution_3d_smoothing_and_refinement():
+    domain = BSplineDomain((9, 8, 7), spacing=(0.7, 1.1, 1.4))
+    image = _blob(domain)
+    result = registration(
+        image,
+        image,
+        domain,
+        shrink_factors=(2, 1),
+        smoothing_sigmas=(0.8, 0.0),
+        iterations=(0, 0),
+        squaring_steps=1,
+    )
+    assert result["coefficients"].shape == (1, 3, 5, 5, 5)
+    assert result["velocity"].shape == (1, 3) + domain.torch_size
+    assert torch.isfinite(result["jacobian_determinant"]).all()
+
+
+def test_verbose_reports_levels_and_iterations(capsys):
+    domain = BSplineDomain((8, 7))
+    image = _blob(domain)
+    registration(
+        image,
+        image,
+        domain,
+        shrink_factors=(2, 1),
+        iterations=(1, 1),
+        squaring_steps=1,
+        verbose=True,
+    )
+    output = capsys.readouterr().out
+    assert "ANTsTorch B-spline SVF registration configuration:" in output
+    assert "similarity: mse" in output
+    assert "stationary_boundary: True" in output
+    assert "shrink_factors: (2, 1)" in output
+    assert "iterations: (1, 1)" in output
+    assert "Resolution level 1/2" in output
+    assert "Resolution level 2/2" in output
+    assert output.count("iteration 0001") == 2
+    assert "loss=" in output
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"optimizer": "sgd"}, "optimizer"),
+        ({"similarity": "mi"}, "similarity"),
+        ({"iterations": -1}, "iterations"),
+        ({"mesh_size": (1, 2, 3)}, "mesh_size"),
+        ({"coefficient_grid_size": 3}, "coefficient_grid_size"),
+        ({"convergence_tolerance": -1.0}, "convergence_tolerance"),
+        ({"shrink_factors": (3, 1)}, "shrink_factors"),
+        ({"shrink_factors": (2, 1), "iterations": (1,)}, "iterations"),
+        ({"shrink_factors": (2, 1), "smoothing_sigmas": (1.0,)}, "smoothing_sigmas"),
+        ({"shrink_factors": (2, 1), "closed": True}, "closed axes"),
+    ],
+)
+def test_registration_parameter_validation(kwargs, match):
+    domain = BSplineDomain((8, 7))
+    image = _blob(domain)
+    with pytest.raises(ValueError, match=match):
+        registration(image, image, domain, **kwargs)
+
+
+def test_registration_rejects_incompatible_image_domain():
+    domain = BSplineDomain((8, 7))
+    with pytest.raises(ValueError, match="fixed tensor shape"):
+        registration(torch.zeros(1, 1, 6, 8), torch.zeros(1, 1, 7, 8), domain)

--- a/tests/bspline_flows/test_similarity.py
+++ b/tests/bspline_flows/test_similarity.py
@@ -1,0 +1,80 @@
+import pytest
+import torch
+
+from antstorch.bspline_flows import ants_neighborhood_correlation_loss
+
+
+def _brute_force_2d(fixed, moving, radius):
+    values = []
+    epsilon = torch.finfo(fixed.dtype).eps
+    radius_x, radius_y = radius
+    for batch in range(fixed.shape[0]):
+        for channel in range(fixed.shape[1]):
+            for y in range(fixed.shape[2]):
+                for x in range(fixed.shape[3]):
+                    f = fixed[
+                        batch,
+                        channel,
+                        max(0, y - radius_y) : y + radius_y + 1,
+                        max(0, x - radius_x) : x + radius_x + 1,
+                    ].flatten()
+                    m = moving[
+                        batch,
+                        channel,
+                        max(0, y - radius_y) : y + radius_y + 1,
+                        max(0, x - radius_x) : x + radius_x + 1,
+                    ].flatten()
+                    fc = f - f.mean()
+                    mc = m - m.mean()
+                    denominator = fc.square().sum() * mc.square().sum()
+                    cc = (
+                        (fc * mc).sum().square() / denominator
+                        if denominator.abs() > epsilon
+                        else denominator.new_tensor(1.0)
+                    )
+                    values.append(cc)
+    return -torch.stack(values).mean()
+
+
+def test_ants_neighborhood_correlation_matches_brute_force_at_boundaries():
+    torch.manual_seed(2)
+    fixed = torch.randn(2, 2, 5, 6, dtype=torch.double)
+    moving = torch.randn_like(fixed)
+    actual = ants_neighborhood_correlation_loss(fixed, moving, radius=(2, 1))
+    expected = _brute_force_2d(fixed, moving, radius=(2, 1))
+    torch.testing.assert_close(actual, expected, rtol=2e-14, atol=2e-14)
+
+
+@pytest.mark.parametrize("shape", [(1, 1, 7, 8), (1, 1, 5, 6, 7)])
+def test_ants_neighborhood_correlation_identical_images_are_minus_one(shape):
+    image = torch.randn(shape, dtype=torch.double)
+    loss = ants_neighborhood_correlation_loss(image, image, radius=2)
+    torch.testing.assert_close(loss, loss.new_tensor(-1.0), rtol=2e-14, atol=2e-14)
+
+
+def test_ants_neighborhood_correlation_has_finite_gradients():
+    fixed = torch.randn(1, 1, 8, 9, dtype=torch.double)
+    moving = torch.randn_like(fixed, requires_grad=True)
+    loss = ants_neighborhood_correlation_loss(fixed, moving, radius=2)
+    loss.backward()
+    assert moving.grad is not None
+    assert torch.isfinite(moving.grad).all()
+    assert moving.grad.abs().max() > 0
+
+
+def test_ants_neighborhood_correlation_constant_background_has_finite_gradients():
+    fixed = torch.zeros(1, 1, 32, 32, dtype=torch.double)
+    fixed[:, :, 10:22, 9:21] = torch.randn(1, 1, 12, 12, dtype=torch.double)
+    moving = torch.roll(fixed, 1, -1).requires_grad_()
+    loss = ants_neighborhood_correlation_loss(fixed, moving, radius=2)
+    loss.backward()
+    assert torch.isfinite(loss)
+    assert moving.grad is not None
+    assert torch.isfinite(moving.grad).all()
+
+
+@pytest.mark.parametrize("radius", [-1, (1,), (1.5, 2)])
+def test_ants_neighborhood_correlation_validates_radius(radius):
+    image = torch.randn(1, 1, 6, 7)
+    with pytest.raises((TypeError, ValueError), match="radius"):
+        ants_neighborhood_correlation_loss(image, image, radius)

--- a/tools/run_registration.py
+++ b/tools/run_registration.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Run ANTsTorch B-spline SVF registration on the ANTs r30/r64 images.
+
+Example
+-------
+Run the default three-level registration on CPU::
+
+    PYTHONPATH=. python tools/run_registration.py
+
+Use an accelerator and fewer iterations::
+
+    PYTHONPATH=. python tools/run_registration.py \
+        --device mps --iterations 40 30 20 --output-dir registration_output
+
+Use the local ANTs neighborhood-correlation metric::
+
+    PYTHONPATH=. python tools/run_registration.py \
+        --similarity ants_ncc --neighborhood-radius 2 --verbose
+"""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import ants
+import numpy as np
+import torch
+
+from antstorch.bspline_flows import BSplineDomain, registration
+
+
+def ants_to_torch(image: ants.ANTsImage, device: torch.device) -> torch.Tensor:
+    """Convert ANTs x-y storage to singleton N-C-Y-X PyTorch storage."""
+    if image.dimension != 2 or image.components != 1:
+        raise ValueError("This example expects a scalar 2-D ANTs image")
+    array = np.ascontiguousarray(image.numpy().astype(np.float32, copy=False).T)
+    return torch.from_numpy(array).unsqueeze(0).unsqueeze(0).to(device)
+
+
+def image_domain(image: ants.ANTsImage) -> BSplineDomain:
+    """Copy all physical-space metadata from an ANTs image."""
+    return BSplineDomain(
+        size=tuple(int(value) for value in image.shape),
+        spacing=tuple(float(value) for value in image.spacing),
+        origin=tuple(float(value) for value in image.origin),
+        direction=tuple(tuple(float(value) for value in row) for row in image.direction),
+    )
+
+
+def torch_image_to_ants(tensor: torch.Tensor, reference: ants.ANTsImage) -> ants.ANTsImage:
+    """Convert a singleton N-C-Y-X tensor to a scalar ANTs image."""
+    array = np.ascontiguousarray(tensor.detach().cpu().numpy()[0, 0].T)
+    return ants.from_numpy(
+        array,
+        origin=reference.origin,
+        spacing=reference.spacing,
+        direction=reference.direction,
+    )
+
+
+def torch_field_to_ants(tensor: torch.Tensor, reference: ants.ANTsImage) -> ants.ANTsImage:
+    """Convert N-(x,y)-Y-X physical vectors to an ANTs vector image."""
+    if tensor.shape[0] != 1 or tensor.shape[1] != 2:
+        raise ValueError("This example expects a singleton batch of 2-D vectors")
+    array = np.ascontiguousarray(tensor.detach().cpu().permute(0, 3, 2, 1).numpy()[0])
+    return ants.from_numpy(
+        array,
+        origin=reference.origin,
+        spacing=reference.spacing,
+        direction=reference.direction,
+        has_components=True,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="cpu", help="PyTorch device: cpu, cuda, or mps")
+    parser.add_argument("--output-dir", type=Path, default=Path("registration_output"))
+    parser.add_argument("--mesh-size", type=int, nargs=2, default=(10, 10), metavar=("X", "Y"))
+    parser.add_argument("--shrink-factors", type=int, nargs="+", default=(8, 4, 2, 1))
+    parser.add_argument("--smoothing-sigmas", type=float, nargs="+", default=(3.0, 2.0, 1.0, 0.0))
+    parser.add_argument("--iterations", type=int, nargs="+", default=(100, 70, 40, 20))
+    parser.add_argument("--learning-rate", type=float, nargs="+", default=(0.03, 0.02, 0.01, 0.005))
+    parser.add_argument("--similarity", choices=("mse", "ncc", "ants_ncc"), default="ants_ncc")
+    parser.add_argument("--neighborhood-radius", type=int, default=2)
+    parser.add_argument("--coefficient-weight", type=float, default=0.0)
+    parser.add_argument("--velocity-weight", type=float, default=0.0)
+    parser.add_argument("--bending-weight", type=float, default=0.0)
+    parser.add_argument("--verbose", action="store_true", help="Print per-level optimization progress")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is not available")
+    if device.type == "mps" and not torch.backends.mps.is_available():
+        raise RuntimeError("MPS was requested but is not available")
+    level_count = len(args.shrink_factors)
+    for name, values in (
+        ("--smoothing-sigmas", args.smoothing_sigmas),
+        ("--iterations", args.iterations),
+        ("--learning-rate", args.learning_rate),
+    ):
+        if len(values) != level_count:
+            raise ValueError(f"{name} must have one value per shrink factor")
+
+    fixed_ants = ants.image_read(ants.get_ants_data("r30")).clone("float")
+    moving_ants = ants.image_read(ants.get_ants_data("r27")).clone("float")
+    fixed = ants_to_torch(fixed_ants, device)
+    moving = ants_to_torch(moving_ants, device)
+    fixed_domain = image_domain(fixed_ants)
+    moving_domain = image_domain(moving_ants)
+
+    start = time.perf_counter()
+    result = registration(
+        fixed=fixed,
+        moving=moving,
+        fixed_domain=fixed_domain,
+        moving_domain=moving_domain,
+        mesh_size=tuple(args.mesh_size),
+        shrink_factors=tuple(args.shrink_factors),
+        smoothing_sigmas=tuple(args.smoothing_sigmas),
+        iterations=tuple(args.iterations),
+        learning_rate=tuple(args.learning_rate),
+        similarity=args.similarity,
+        neighborhood_radius=args.neighborhood_radius,
+        coefficient_weight=args.coefficient_weight,
+        velocity_weight=args.velocity_weight,
+        bending_weight=args.bending_weight,
+        padding_mode="border",
+        stationary_boundary=True,
+        verbose=args.verbose,
+    )
+    elapsed = time.perf_counter() - start
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    ants.image_write(fixed_ants, str(args.output_dir / "fixed_r30.nii.gz"))
+    ants.image_write(moving_ants, str(args.output_dir / "moving_r27.nii.gz"))
+    ants.image_write(
+        torch_image_to_ants(result["warped_moving"], fixed_ants),
+        str(args.output_dir / "warped_r27.nii.gz"),
+    )
+    for name in ("velocity", "forward_displacement", "inverse_displacement"):
+        ants.image_write(
+            torch_field_to_ants(result[name], fixed_ants),
+            str(args.output_dir / f"{name}.nii.gz"),
+        )
+    torch.save(result["coefficients"].cpu(), args.output_dir / "coefficients.pt")
+    with (args.output_dir / "loss_history.json").open("w", encoding="utf-8") as stream:
+        json.dump(result["level_loss_history"], stream, indent=2)
+
+    print(f"Registration completed in {elapsed:.2f} seconds on {device}.")
+    print(f"Final loss: {result['loss'].item():.6g}")
+    print(f"Outputs written to: {args.output_dir.resolve()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add high-level multi-resolution B-spline SVF registration

- add a differentiable 2D/3D registration API with Adam and LBFGS
- parameterize stationary velocity fields with compact B-spline control grids,
  reducing the number of optimized parameters while producing smooth,
  spatially coherent deformations
- support exact coarse-to-fine B-spline coefficient refinement, preserving the
  current transformation when moving between pyramid levels
- expose coefficient, velocity, and bending-energy regularization for direct
  control over deformation magnitude and smoothness
- compute diffeomorphic forward and inverse transforms as exp(v) and exp(-v)
- support multi-resolution image pyramids with consistent physical geometry
- add MSE, global NCC, and local ANTs neighborhood correlation
- support distinct physical fixed and moving image domains
- add convergence monitoring, detached output control, and verbose reporting
- add an r16/r27 registration example with NIfTI outputs
- fail fast on non-finite losses or gradients
- add registration, similarity, gradient, and multi-resolution tests

----------

Example:  

```bash
% python3 run_registration.py --device cpu --similarity ants_ncc --neighborhood-radius 2 --verbose
ANTsTorch B-spline SVF registration configuration:
  fixed_domain: BSplineDomain(size=(256, 256), spacing=(1.0, 1.0), origin=(0.0, 0.0), direction=((1.0, 0.0), (0.0, 1.0)))
  moving_domain: BSplineDomain(size=(256, 256), spacing=(1.0, 1.0), origin=(0.0, 0.0), direction=((1.0, 0.0), (0.0, 1.0)))
  fixed_shape: (1, 1, 256, 256)
  moving_shape: (1, 1, 256, 256)
  dtype: torch.float32
  device: cpu
  initial_coefficient_shape: (1, 2, 13, 13)
  mesh_size: (10, 10)
  coefficient_grid_size: None
  initial_coefficients_provided: False
  shrink_factors: (8, 4, 2, 1)
  smoothing_sigmas: (3.0, 2.0, 1.0, 0.0)
  iterations: (100, 70, 40, 20)
  learning_rate: (0.03, 0.02, 0.01, 0.005)
  optimizer: adam
  similarity: ants_ncc
  neighborhood_radius: 2
  coefficient_weight: 0.0
  velocity_weight: 0.0
  bending_weight: 0.0
  squaring_steps: 7
  padding_mode: border
  closed: False
  stationary_boundary: True
  convergence_tolerance: None
  return_loss_history: True
  detach_outputs: True
  synthesis_chunk_size: 262144
Resolution level 1/4: shrink_factor=8, smoothing_sigma=3, fixed_size=(32, 32), moving_size=(32, 32), iterations=100
  iteration 0001: loss=-0.92060572
  iteration 0002: loss=-0.92132413
  iteration 0003: loss=-0.92193979
  iteration 0004: loss=-0.92238271
  iteration 0005: loss=-0.92281163
  iteration 0006: loss=-0.92316836
  iteration 0007: loss=-0.92349982
  iteration 0008: loss=-0.9238351
  iteration 0009: loss=-0.92417049
  iteration 0010: loss=-0.92450196
  iteration 0011: loss=-0.9248268
  iteration 0012: loss=-0.92514443
  iteration 0013: loss=-0.92545515
  iteration 0014: loss=-0.92574346
  iteration 0015: loss=-0.92603236
  iteration 0016: loss=-0.92632252
  iteration 0017: loss=-0.9266144
  iteration 0018: loss=-0.92690653
  iteration 0019: loss=-0.92719913
  iteration 0020: loss=-0.92748868
  iteration 0021: loss=-0.92776912
  iteration 0022: loss=-0.92804873
  iteration 0023: loss=-0.92832768
  iteration 0024: loss=-0.92860526
  iteration 0025: loss=-0.92888242
  iteration 0026: loss=-0.92915416
  iteration 0027: loss=-0.92941809
  iteration 0028: loss=-0.92967319
  iteration 0029: loss=-0.92992425
  iteration 0030: loss=-0.93017536
  iteration 0031: loss=-0.93042946
  iteration 0032: loss=-0.93068349
  iteration 0033: loss=-0.93093348
  iteration 0034: loss=-0.93116945
  iteration 0035: loss=-0.93140817
  iteration 0036: loss=-0.93165094
  iteration 0037: loss=-0.93189198
  iteration 0038: loss=-0.93212849
  iteration 0039: loss=-0.93236178
  iteration 0040: loss=-0.93259364
  iteration 0041: loss=-0.93282366
  iteration 0042: loss=-0.93305111
  iteration 0043: loss=-0.93327379
  iteration 0044: loss=-0.93349373
  iteration 0045: loss=-0.93371296
  iteration 0046: loss=-0.93393028
  iteration 0047: loss=-0.93414664
  iteration 0048: loss=-0.9343617
  iteration 0049: loss=-0.93457454
  iteration 0050: loss=-0.93478477
  iteration 0051: loss=-0.93499136
  iteration 0052: loss=-0.9351964
  iteration 0053: loss=-0.93539989
  iteration 0054: loss=-0.93560207
  iteration 0055: loss=-0.9358018
  iteration 0056: loss=-0.93600029
  iteration 0057: loss=-0.93619609
  iteration 0058: loss=-0.93639117
  iteration 0059: loss=-0.936584
  iteration 0060: loss=-0.93677354
  iteration 0061: loss=-0.93696213
  iteration 0062: loss=-0.93715066
  iteration 0063: loss=-0.93733639
  iteration 0064: loss=-0.9375208
  iteration 0065: loss=-0.93770289
  iteration 0066: loss=-0.93788451
  iteration 0067: loss=-0.93806446
  iteration 0068: loss=-0.93824315
  iteration 0069: loss=-0.93841982
  iteration 0070: loss=-0.93859494
  iteration 0071: loss=-0.93876708
  iteration 0072: loss=-0.93893856
  iteration 0073: loss=-0.93910837
  iteration 0074: loss=-0.93927789
  iteration 0075: loss=-0.93944567
  iteration 0076: loss=-0.93961132
  iteration 0077: loss=-0.93977422
  iteration 0078: loss=-0.9399364
  iteration 0079: loss=-0.94009656
  iteration 0080: loss=-0.94025606
  iteration 0081: loss=-0.94041353
  iteration 0082: loss=-0.94057024
  iteration 0083: loss=-0.94072497
  iteration 0084: loss=-0.94087839
  iteration 0085: loss=-0.94103545
  iteration 0086: loss=-0.94119102
  iteration 0087: loss=-0.94134706
  iteration 0088: loss=-0.94150424
  iteration 0089: loss=-0.94165999
  iteration 0090: loss=-0.94181496
  iteration 0091: loss=-0.94196904
  iteration 0092: loss=-0.94212157
  iteration 0093: loss=-0.94227278
  iteration 0094: loss=-0.94242471
  iteration 0095: loss=-0.94257504
  iteration 0096: loss=-0.94272292
  iteration 0097: loss=-0.94286776
  iteration 0098: loss=-0.94301069
  iteration 0099: loss=-0.94315279
  iteration 0100: loss=-0.9432953
Resolution level 2/4: shrink_factor=4, smoothing_sigma=2, fixed_size=(64, 64), moving_size=(64, 64), iterations=70
  iteration 0001: loss=-0.89186251
  iteration 0002: loss=-0.89229685
  iteration 0003: loss=-0.89272404
  iteration 0004: loss=-0.89314294
  iteration 0005: loss=-0.89355719
  iteration 0006: loss=-0.89396936
  iteration 0007: loss=-0.89436531
  iteration 0008: loss=-0.8947736
  iteration 0009: loss=-0.89517546
  iteration 0010: loss=-0.89557248
  iteration 0011: loss=-0.8959657
  iteration 0012: loss=-0.89635944
  iteration 0013: loss=-0.89671695
  iteration 0014: loss=-0.89710522
  iteration 0015: loss=-0.89748502
  iteration 0016: loss=-0.89785689
  iteration 0017: loss=-0.89821953
  iteration 0018: loss=-0.89858055
  iteration 0019: loss=-0.89893985
  iteration 0020: loss=-0.8992933
  iteration 0021: loss=-0.89963931
  iteration 0022: loss=-0.89997727
  iteration 0023: loss=-0.90030867
  iteration 0024: loss=-0.90063453
  iteration 0025: loss=-0.90095711
  iteration 0026: loss=-0.90127271
  iteration 0027: loss=-0.90158153
  iteration 0028: loss=-0.90188497
  iteration 0029: loss=-0.90218544
  iteration 0030: loss=-0.90248036
  iteration 0031: loss=-0.90276968
  iteration 0032: loss=-0.90305454
  iteration 0033: loss=-0.903341
  iteration 0034: loss=-0.90362394
  iteration 0035: loss=-0.90390211
  iteration 0036: loss=-0.90417695
  iteration 0037: loss=-0.90444624
  iteration 0038: loss=-0.90471101
  iteration 0039: loss=-0.90497142
  iteration 0040: loss=-0.90522575
  iteration 0041: loss=-0.90547669
  iteration 0042: loss=-0.90572315
  iteration 0043: loss=-0.90596509
  iteration 0044: loss=-0.90620369
  iteration 0045: loss=-0.9064377
  iteration 0046: loss=-0.9066689
  iteration 0047: loss=-0.90689647
  iteration 0048: loss=-0.9071213
  iteration 0049: loss=-0.90734506
  iteration 0050: loss=-0.90756661
  iteration 0051: loss=-0.90778607
  iteration 0052: loss=-0.90800273
  iteration 0053: loss=-0.90821916
  iteration 0054: loss=-0.90843225
  iteration 0055: loss=-0.9086405
  iteration 0056: loss=-0.90885031
  iteration 0057: loss=-0.90906131
  iteration 0058: loss=-0.90927124
  iteration 0059: loss=-0.90947908
  iteration 0060: loss=-0.90968525
  iteration 0061: loss=-0.90988946
  iteration 0062: loss=-0.91009128
  iteration 0063: loss=-0.91029119
  iteration 0064: loss=-0.91048729
  iteration 0065: loss=-0.91068101
  iteration 0066: loss=-0.91087329
  iteration 0067: loss=-0.9110629
  iteration 0068: loss=-0.91124994
  iteration 0069: loss=-0.91143548
  iteration 0070: loss=-0.91161907
Resolution level 3/4: shrink_factor=2, smoothing_sigma=1, fixed_size=(128, 128), moving_size=(128, 128), iterations=40
  iteration 0001: loss=-0.84697193
  iteration 0002: loss=-0.84744108
  iteration 0003: loss=-0.84784782
  iteration 0004: loss=-0.84824967
  iteration 0005: loss=-0.84865546
  iteration 0006: loss=-0.84905106
  iteration 0007: loss=-0.84944606
  iteration 0008: loss=-0.84984523
  iteration 0009: loss=-0.85023141
  iteration 0010: loss=-0.85060775
  iteration 0011: loss=-0.85097766
  iteration 0012: loss=-0.85136002
  iteration 0013: loss=-0.85172546
  iteration 0014: loss=-0.85208726
  iteration 0015: loss=-0.85244679
  iteration 0016: loss=-0.85280275
  iteration 0017: loss=-0.85315728
  iteration 0018: loss=-0.85350937
  iteration 0019: loss=-0.85386646
  iteration 0020: loss=-0.85421586
  iteration 0021: loss=-0.85456228
  iteration 0022: loss=-0.85490882
  iteration 0023: loss=-0.85525256
  iteration 0024: loss=-0.85560817
  iteration 0025: loss=-0.85595
  iteration 0026: loss=-0.85628974
  iteration 0027: loss=-0.85662681
  iteration 0028: loss=-0.85695899
  iteration 0029: loss=-0.85728717
  iteration 0030: loss=-0.85761529
  iteration 0031: loss=-0.85794175
  iteration 0032: loss=-0.85825646
  iteration 0033: loss=-0.85860884
  iteration 0034: loss=-0.85892922
  iteration 0035: loss=-0.85923618
  iteration 0036: loss=-0.85955131
  iteration 0037: loss=-0.85986412
  iteration 0038: loss=-0.86017513
  iteration 0039: loss=-0.86048651
  iteration 0040: loss=-0.86079615
Resolution level 4/4: shrink_factor=1, smoothing_sigma=0, fixed_size=(256, 256), moving_size=(256, 256), iterations=20
  iteration 0001: loss=-0.80535245
  iteration 0002: loss=-0.80562562
  iteration 0003: loss=-0.80583739
  iteration 0004: loss=-0.80612594
  iteration 0005: loss=-0.80638349
  iteration 0006: loss=-0.80668634
  iteration 0007: loss=-0.80697393
  iteration 0008: loss=-0.80726016
  iteration 0009: loss=-0.807531
  iteration 0010: loss=-0.80781627
  iteration 0011: loss=-0.8081004
  iteration 0012: loss=-0.80838388
  iteration 0013: loss=-0.80866718
  iteration 0014: loss=-0.80894911
  iteration 0015: loss=-0.80923057
  iteration 0016: loss=-0.80951118
  iteration 0017: loss=-0.80979276
  iteration 0018: loss=-0.8100732
  iteration 0019: loss=-0.81035268
  iteration 0020: loss=-0.81059754
Registration completed in 2.35 seconds on cpu.
Final loss: -0.810598
Outputs written to: ./registration_output
```